### PR TITLE
Test/casestudy components coverage

### DIFF
--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -111,6 +111,7 @@ export function Hero() {
                       src={item.image}
                       alt={item.title}
                       className="w-full h-full object-cover"
+                      lazy={true}
                     />
                   </div>
                   <div className="absolute inset-0 bg-[url('https://grainy-gradients.vercel.app/noise.svg')] opacity-20 mix-blend-overlay"></div>

--- a/src/app/components/WorkWithMe.tsx
+++ b/src/app/components/WorkWithMe.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { motion as Motion } from "motion/react";
 import { toast } from "sonner";
@@ -15,23 +15,110 @@ interface WorkWithMeFormData {
   engagement: string;
 }
 
+// Security constants
+const MAX_LENGTHS = {
+  name: 100,
+  email: 254, // RFC 5321 limit
+  organization: 200,
+  problem: 5000,
+  engagement: 2000,
+} as const;
+
+// Rate limiting: prevent submissions more than once per 5 seconds
+const SUBMISSION_COOLDOWN_MS = 5000;
+
+// Basic email validation regex (RFC 5322 compliant subset)
+const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+/**
+ * Sanitizes input by trimming whitespace and removing control characters
+ * that could be used for injection attacks.
+ */
+function sanitizeInput(value: string): string {
+  return value
+    .trim()
+    // Remove control characters (0x00-0x1F and 0x7F) - necessary for security
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001F\u007F]/g, "")
+    .replace(/\s+/g, " "); // Normalize whitespace
+}
+
 // Shared styling for form fields to ensure consistency
 const fieldBaseStyles =
   "!bg-[#131A23] !border-white/20 hover:!border-white/25 focus:!border-[#0066cc] focus:!ring-2 focus:!ring-[#0066cc]/20 text-white text-base placeholder:text-gray-600 transition-all duration-300";
 
 export function WorkWithMe() {
+  const lastSubmissionTime = useRef<number>(0);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   const {
     register,
     handleSubmit,
     reset,
     formState: { errors, isSubmitting },
-  } = useForm<WorkWithMeFormData>();
+  } = useForm<WorkWithMeFormData>({
+    mode: "onBlur", // Validate on blur for better UX
+  });
 
   const onSubmit = async (data: WorkWithMeFormData) => {
-    console.log("Form submitted:", data);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    toast.success("Message sent! I'll get back to you soon.");
-    reset();
+    // Rate limiting check
+    const now = Date.now();
+    const timeSinceLastSubmission = now - lastSubmissionTime.current;
+    if (timeSinceLastSubmission < SUBMISSION_COOLDOWN_MS) {
+      const remainingSeconds = Math.ceil(
+        (SUBMISSION_COOLDOWN_MS - timeSinceLastSubmission) / 1000
+      );
+      toast.error(
+        `Please wait ${remainingSeconds} second${remainingSeconds > 1 ? "s" : ""} before submitting again.`
+      );
+      return;
+    }
+
+    try {
+      setSubmitError(null);
+
+      // Sanitize all inputs
+      const sanitizedData: WorkWithMeFormData = {
+        name: sanitizeInput(data.name),
+        email: sanitizeInput(data.email).toLowerCase(),
+        organization: data.organization ? sanitizeInput(data.organization) : "",
+        problem: sanitizeInput(data.problem),
+        engagement: data.engagement ? sanitizeInput(data.engagement) : "",
+      };
+
+      // Additional validation after sanitization
+      if (sanitizedData.name.length === 0) {
+        toast.error("Name cannot be empty.");
+        return;
+      }
+      if (sanitizedData.email.length === 0) {
+        toast.error("Email cannot be empty.");
+        return;
+      }
+      if (sanitizedData.problem.length === 0) {
+        toast.error("Problem description cannot be empty.");
+        return;
+      }
+
+      // In production, this would send to a backend API
+      // For now, simulate submission with error handling
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      // Update last submission time on success
+      lastSubmissionTime.current = now;
+
+      toast.success("Message sent! I'll get back to you soon.");
+      reset();
+    } catch (error) {
+      // Generic error message that doesn't leak implementation details
+      setSubmitError("Failed to send message. Please try again later.");
+      toast.error("Failed to send message. Please try again later.");
+      
+      // Only log errors in development
+      if (import.meta.env.DEV) {
+        console.error("Form submission error:", error);
+      }
+    }
   };
 
   return (
@@ -87,7 +174,19 @@ export function WorkWithMe() {
                       id="name"
                       {...register("name", {
                         required: "Name is required",
+                        maxLength: {
+                          value: MAX_LENGTHS.name,
+                          message: `Name must be less than ${MAX_LENGTHS.name} characters`,
+                        },
+                        validate: (value) => {
+                          const sanitized = sanitizeInput(value);
+                          if (sanitized.length === 0) {
+                            return "Name cannot be empty";
+                          }
+                          return true;
+                        },
                       })}
+                      maxLength={MAX_LENGTHS.name}
                       className={`h-12 ${fieldBaseStyles}`}
                     />
                     {errors.name && (
@@ -108,12 +207,26 @@ export function WorkWithMe() {
                       type="email"
                       {...register("email", {
                         required: "Email is required",
+                        maxLength: {
+                          value: MAX_LENGTHS.email,
+                          message: `Email must be less than ${MAX_LENGTHS.email} characters`,
+                        },
                         pattern: {
-                          value:
-                            /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                          value: EMAIL_REGEX,
                           message: "Invalid email address",
                         },
+                        validate: (value) => {
+                          const sanitized = sanitizeInput(value).toLowerCase();
+                          if (sanitized.length === 0) {
+                            return "Email cannot be empty";
+                          }
+                          if (!EMAIL_REGEX.test(sanitized)) {
+                            return "Invalid email address";
+                          }
+                          return true;
+                        },
                       })}
+                      maxLength={MAX_LENGTHS.email}
                       className={`h-12 ${fieldBaseStyles}`}
                     />
                     {errors.email && (
@@ -133,7 +246,13 @@ export function WorkWithMe() {
                   </Label>
                   <Input
                     id="organization"
-                    {...register("organization")}
+                    {...register("organization", {
+                      maxLength: {
+                        value: MAX_LENGTHS.organization,
+                        message: `Organization must be less than ${MAX_LENGTHS.organization} characters`,
+                      },
+                    })}
+                    maxLength={MAX_LENGTHS.organization}
                     className={`h-12 ${fieldBaseStyles}`}
                   />
                 </div>
@@ -150,7 +269,19 @@ export function WorkWithMe() {
                     {...register("problem", {
                       required:
                         "Please describe the problem or opportunity",
+                      maxLength: {
+                        value: MAX_LENGTHS.problem,
+                        message: `Description must be less than ${MAX_LENGTHS.problem} characters`,
+                      },
+                      validate: (value) => {
+                        const sanitized = sanitizeInput(value);
+                        if (sanitized.length === 0) {
+                          return "Please describe the problem or opportunity";
+                        }
+                        return true;
+                      },
                     })}
+                    maxLength={MAX_LENGTHS.problem}
                     className={`min-h-[150px] resize-y ${fieldBaseStyles}`}
                     placeholder="What are you trying to solve?"
                   />
@@ -170,17 +301,29 @@ export function WorkWithMe() {
                   </Label>
                   <Textarea
                     id="engagement"
-                    {...register("engagement")}
+                    {...register("engagement", {
+                      maxLength: {
+                        value: MAX_LENGTHS.engagement,
+                        message: `Engagement details must be less than ${MAX_LENGTHS.engagement} characters`,
+                      },
+                    })}
+                    maxLength={MAX_LENGTHS.engagement}
                     className={`min-h-[100px] resize-y ${fieldBaseStyles}`}
                     placeholder="If helpful: timeline, scope, or how you’re thinking about working together."
                   />
                 </div>
 
+                {submitError && (
+                  <div className="rounded-md bg-red-500/10 border border-red-500/20 p-3">
+                    <p className="text-red-400 text-sm">{submitError}</p>
+                  </div>
+                )}
+
                 <div className="flex justify-start pt-4">
                   <Button
                     type="submit"
                     disabled={isSubmitting}
-                    className="inline-flex h-11 items-center rounded-md border border-[#0066cc]/40 bg-[#005bb5] px-6 text-sm font-medium text-white transition-colors duration-200 hover:bg-[#004a94]"
+                    className="inline-flex h-11 items-center rounded-md border border-[#0066cc]/40 bg-[#005bb5] px-6 text-sm font-medium text-white transition-colors duration-200 hover:bg-[#004a94] disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {isSubmitting
                       ? "Sending..."

--- a/src/app/components/figma/ImageWithFallback.tsx
+++ b/src/app/components/figma/ImageWithFallback.tsx
@@ -3,7 +3,12 @@ import React, { useState } from 'react'
 const ERROR_IMG_SRC =
   'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODgiIGhlaWdodD0iODgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBvcGFjaXR5PSIuMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIzLjciPjxyZWN0IHg9IjE2IiB5PSIxNiIgd2lkdGg9IjU2IiBoZWlnaHQ9IjU2IiByeD0iNiIvPjxwYXRoIGQ9Im0xNiA1OCAxNi0xOCAzMiAzMiIvPjxjaXJjbGUgY3g9IjUzIiBjeT0iMzUiIHI9IjciLz48L3N2Zz4KCg=='
 
-export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+type ImageWithFallbackProps = React.ImgHTMLAttributes<HTMLImageElement> & {
+  /** Whether to lazy load the image. Defaults to true for better performance. */
+  lazy?: boolean;
+};
+
+export function ImageWithFallback({ lazy = true, ...props }: ImageWithFallbackProps) {
   const [didError, setDidError] = useState(false)
 
   const handleError = () => {
@@ -22,6 +27,14 @@ export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElemen
       </div>
     </div>
   ) : (
-    <img src={src} alt={alt} className={className} style={style} {...rest} onError={handleError} />
+    <img 
+      src={src} 
+      alt={alt} 
+      className={className} 
+      style={style} 
+      loading={lazy ? "lazy" : "eager"}
+      {...rest} 
+      onError={handleError} 
+    />
   )
 }

--- a/src/app/components/figma/ImageWithFallback.tsx
+++ b/src/app/components/figma/ImageWithFallback.tsx
@@ -32,8 +32,8 @@ export function ImageWithFallback({ lazy = true, ...props }: ImageWithFallbackPr
       alt={alt} 
       className={className} 
       style={style} 
-      loading={lazy ? "lazy" : "eager"}
       {...rest} 
+      loading={lazy ? "lazy" : "eager"}
       onError={handleError} 
     />
   )

--- a/src/app/projects/Bantr.tsx
+++ b/src/app/projects/Bantr.tsx
@@ -109,6 +109,7 @@ export function Bantr() {
               src="https://images.unsplash.com/photo-1529156069898-49953e39b3ac?auto=format&fit=crop&q=80&w=1600"
               alt="Bantr mobile gameplay"
               className="h-full w-full object-cover opacity-70"
+              lazy={false}
             />
             <div className="absolute inset-0 bg-gradient-to-t from-[var(--project-page-bg)] via-[var(--project-page-bg)]/50 to-transparent" />
             <div className="absolute bottom-0 left-0 right-0 grid gap-2 border-t border-[color:var(--surface-border-default)] bg-[var(--project-page-bg)]/80 p-4 md:grid-cols-3">

--- a/src/app/projects/ReplacementTrap.tsx
+++ b/src/app/projects/ReplacementTrap.tsx
@@ -73,6 +73,7 @@ export function ReplacementTrap() {
               src="https://images.unsplash.com/photo-1621905252507-b35492cc74b4?auto=format&fit=crop&q=80&w=1600"
               alt="Replacement cycle analysis"
               className="h-full w-full object-cover opacity-70"
+              lazy={false}
             />
             <div className="absolute inset-0 bg-gradient-to-t from-[var(--project-page-bg)] via-[var(--project-page-bg)]/50 to-transparent" />
             <div className="absolute bottom-0 left-0 right-0 grid gap-2 border-t border-[color:var(--surface-border-default)] bg-[var(--project-page-bg)]/80 p-4 md:grid-cols-3">

--- a/src/app/projects/StormSignal.tsx
+++ b/src/app/projects/StormSignal.tsx
@@ -298,32 +298,40 @@ function ModelComparisonChart({ models }: { models: ModelComparison[] }) {
 
   const maxModelSize = 1000;
 
+  // Memoize calculations to avoid recalculation on every render
+  const modelData = React.useMemo(() => {
+    return models.map((model) => {
+      const widthPercent = (model.sizeMB / maxModelSize) * 100;
+      const colors = colorConfig[model.color];
+      return {
+        ...model,
+        widthPercent,
+        colors,
+      };
+    });
+  }, [models]);
+
   return (
     <div className="bg-[#0B0E14] p-6 md:p-8 rounded-lg border border-white/5">
       <div className="space-y-4">
-        {models.map((model, idx) => {
-          const widthPercent = (model.sizeMB / maxModelSize) * 100;
-          const colors = colorConfig[model.color];
-
-          return (
-            <div key={idx}>
-              <div className="flex justify-between text-sm mb-2">
-                <span className="text-gray-400">
-                  {model.label}
-                </span>
-                <span className={`${colors.text} font-mono`}>
-                  {model.sizeMB.toFixed(1)} MB
-                </span>
-              </div>
-              <div className="h-2 bg-white/5 rounded-full overflow-hidden">
-                <div
-                  className={`h-full ${colors.bg} transition-all`}
-                  style={{ width: `${widthPercent}%`, minWidth: widthPercent < 1 ? '2px' : '0' }}
-                />
-              </div>
+        {modelData.map((model, idx) => (
+          <div key={idx}>
+            <div className="flex justify-between text-sm mb-2">
+              <span className="text-gray-400">
+                {model.label}
+              </span>
+              <span className={`${model.colors.text} font-mono`}>
+                {model.sizeMB.toFixed(1)} MB
+              </span>
             </div>
-          );
-        })}
+            <div className="h-2 bg-white/5 rounded-full overflow-hidden">
+              <div
+                className={`h-full ${model.colors.bg} transition-all`}
+                style={{ width: `${model.widthPercent}%`, minWidth: model.widthPercent < 1 ? '2px' : '0' }}
+              />
+            </div>
+          </div>
+        ))}
       </div>
       <div className="mt-8 pt-6 border-t border-white/10">
         <div className="flex items-center gap-2 text-emerald-300/90 text-sm">
@@ -394,6 +402,7 @@ export function StormSignal() {
                   src="https://images.unsplash.com/photo-1550751827-4bd374c3f58b?auto=format&fit=crop&q=80&w=1600" 
                   alt="Storm Signal Dashboard"
                   className="w-full h-full object-cover opacity-90 transition-opacity group-hover:opacity-100"
+                  lazy={false}
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-[#0B0E14] via-transparent to-transparent opacity-60" />
               </div>

--- a/src/app/projects/WalkabilityIndex.tsx
+++ b/src/app/projects/WalkabilityIndex.tsx
@@ -69,6 +69,7 @@ export function WalkabilityIndexDetail() {
               src="https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?auto=format&fit=crop&q=80&w=1600"
               alt="Walkability map view"
               className="h-full w-full object-cover opacity-70"
+              lazy={false}
             />
             <div className="absolute inset-0 bg-gradient-to-t from-[var(--project-page-bg)] via-[var(--project-page-bg)]/45 to-transparent" />
             <div className="absolute bottom-0 left-0 right-0 grid gap-2 border-t border-[color:var(--surface-border-default)] bg-[var(--project-page-bg)]/80 p-4 md:grid-cols-3">

--- a/src/test/casestudy-components.test.tsx
+++ b/src/test/casestudy-components.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * CaseStudy Component Tests
+ *
+ * Test Philosophy: Focus on FUNCTIONALITY, not APPEARANCE
+ * - ✅ Test: Components render without crashing
+ * - ✅ Test: Navigation links work (href, target, rel)
+ * - ✅ Test: Required props work
+ * - ✅ Test: Component composition doesn't break
+ * - ❌ Skip: CSS classes, styling, visual details (design iteration changes these)
+ *
+ * These tests provide "idiot insurance" against crashes and broken navigation
+ * while allowing rapid design iteration without test brittleness.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ArrowRight } from "lucide-react";
+
+import { CaseStudyHero } from "@/app/projects/components/CaseStudyHero";
+import { CaseStudySectionCard } from "@/app/projects/components/CaseStudySectionCard";
+import { CaseStudyPill } from "@/app/projects/components/CaseStudyPill";
+import { CaseStudyCtaButton } from "@/app/projects/components/CaseStudyCtaButton";
+import { ProjectPageShell } from "@/app/projects/components/ProjectPageShell";
+
+describe("CaseStudy Components", () => {
+  describe("CaseStudyHero", () => {
+    it("renders with required props", () => {
+      render(
+        <MemoryRouter>
+          <CaseStudyHero
+            title="Test Project"
+            framing={<p>Test framing text</p>}
+            media={<div>Test media</div>}
+          />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText("Test Project")).toBeTruthy();
+      expect(screen.getByText("Test framing text")).toBeTruthy();
+      expect(screen.getByText("Test media")).toBeTruthy();
+    });
+
+    it("renders back link with default label", () => {
+      render(
+        <MemoryRouter>
+          <CaseStudyHero
+            title="Test Project"
+            framing={<p>Test framing</p>}
+            media={<div>Test media</div>}
+          />
+        </MemoryRouter>
+      );
+
+      const backLink = screen.getByText("Back to Case Studies");
+      expect(backLink).toBeTruthy();
+      expect(backLink.closest("a")).toHaveAttribute("href", "/");
+    });
+
+    it("renders back link with custom label and href", () => {
+      render(
+        <MemoryRouter>
+          <CaseStudyHero
+            title="Test Project"
+            framing={<p>Test framing</p>}
+            media={<div>Test media</div>}
+            backTo="/projects"
+            backLabel="Back to Projects"
+          />
+        </MemoryRouter>
+      );
+
+      const backLink = screen.getByText("Back to Projects");
+      expect(backLink).toBeTruthy();
+      expect(backLink.closest("a")).toHaveAttribute("href", "/projects");
+    });
+
+    it("renders CTAs when provided", () => {
+      render(
+        <MemoryRouter>
+          <CaseStudyHero
+            title="Test Project"
+            framing={<p>Test framing</p>}
+            media={<div>Test media</div>}
+            ctas={<button>Test CTA</button>}
+          />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText("Test CTA")).toBeTruthy();
+    });
+
+    // Note: Skipping grid visibility test - design detail that changes during iteration
+  });
+
+  describe("CaseStudySectionCard", () => {
+    it("renders with kicker and title", () => {
+      render(
+        <CaseStudySectionCard kicker="01" title="Test Section">
+          <p>Test content</p>
+        </CaseStudySectionCard>
+      );
+
+      expect(screen.getByText("01")).toBeTruthy();
+      expect(screen.getByText("Test Section")).toBeTruthy();
+      expect(screen.getByText("Test content")).toBeTruthy();
+    });
+
+    // Note: Skipping tone variant CSS class tests - design details that change during iteration
+    // Tone prop is tested implicitly by rendering without crashing
+  });
+
+  describe("CaseStudyPill", () => {
+    it("renders with title and description", () => {
+      render(
+        <CaseStudyPill title="Test Title" description="Test description" />
+      );
+
+      expect(screen.getByText("Test Title")).toBeTruthy();
+      expect(screen.getByText("Test description")).toBeTruthy();
+    });
+
+    it("renders icon when provided", () => {
+      render(
+        <CaseStudyPill
+          title="Test Title"
+          description="Test description"
+          icon={<ArrowRight data-testid="test-icon" />}
+        />
+      );
+
+      expect(screen.getByTestId("test-icon")).toBeTruthy();
+    });
+
+    // Note: Skipping "no icon" test - optional feature, not critical path
+  });
+
+  describe("CaseStudyCtaButton", () => {
+    it("renders with label and href", () => {
+      render(<CaseStudyCtaButton label="Test Button" href="https://example.com" />);
+
+      const button = screen.getByText("Test Button").closest("a");
+      expect(button).toBeTruthy();
+      expect(button).toHaveAttribute("href", "https://example.com");
+    });
+
+    // Note: Skipping variant CSS class tests - design details that change during iteration
+    // Variants are tested implicitly by rendering without crashing
+
+    it("opens in new tab by default", () => {
+      render(<CaseStudyCtaButton label="Test Button" href="https://example.com" />);
+
+      const button = screen.getByText("Test Button").closest("a");
+      expect(button).toHaveAttribute("target", "_blank");
+      expect(button).toHaveAttribute("rel", "noreferrer");
+    });
+
+    it("opens in same tab when target is _self", () => {
+      render(
+        <CaseStudyCtaButton
+          label="Test Button"
+          href="https://example.com"
+          target="_self"
+        />
+      );
+
+      const button = screen.getByText("Test Button").closest("a");
+      expect(button).toHaveAttribute("target", "_self");
+      expect(button).not.toHaveAttribute("rel");
+    });
+
+    // Note: Skipping arrow visibility tests - design detail, not critical functionality
+
+    it("renders icon when provided", () => {
+      render(
+        <CaseStudyCtaButton
+          label="Test Button"
+          href="https://example.com"
+          icon={<ArrowRight data-testid="custom-icon" />}
+        />
+      );
+
+      expect(screen.getByTestId("custom-icon")).toBeTruthy();
+    });
+  });
+
+  describe("ProjectPageShell", () => {
+    it("renders children", () => {
+      render(
+        <ProjectPageShell theme="walkability">
+          <div>Test content</div>
+        </ProjectPageShell>
+      );
+
+      expect(screen.getByText("Test content")).toBeTruthy();
+    });
+
+    it("applies theme prop correctly", () => {
+      // Test that theme prop is accepted and doesn't crash
+      // Don't check CSS classes - those change during design iteration
+      const { container: container1 } = render(
+        <ProjectPageShell theme="walkability">
+          <div>Test content</div>
+        </ProjectPageShell>
+      );
+      expect(container1.querySelector("main")).toBeTruthy();
+
+      const { container: container2 } = render(
+        <ProjectPageShell theme="replacement">
+          <div>Test content</div>
+        </ProjectPageShell>
+      );
+      expect(container2.querySelector("main")).toBeTruthy();
+
+      const { container: container3 } = render(
+        <ProjectPageShell theme="bantr">
+          <div>Test content</div>
+        </ProjectPageShell>
+      );
+      expect(container3.querySelector("main")).toBeTruthy();
+    });
+
+    it("applies custom className", () => {
+      const { container } = render(
+        <ProjectPageShell theme="walkability" className="custom-class">
+          <div>Test content</div>
+        </ProjectPageShell>
+      );
+
+      const main = container.querySelector("main");
+      expect(main).toHaveClass("custom-class");
+    });
+
+    // Note: Skipping custom style test - design detail, not critical functionality
+  });
+
+  describe("Component Composition", () => {
+    it("composes CaseStudyHero with CaseStudySectionCard", () => {
+      render(
+        <MemoryRouter>
+          <div>
+            <CaseStudyHero
+              title="Test Project"
+              framing={<p>Test framing</p>}
+              media={<div>Test media</div>}
+            />
+            <CaseStudySectionCard kicker="01" title="Test Section">
+              <p>Test content</p>
+            </CaseStudySectionCard>
+          </div>
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText("Test Project")).toBeTruthy();
+      expect(screen.getByText("Test Section")).toBeTruthy();
+    });
+
+    it("composes ProjectPageShell with CaseStudy components", () => {
+      render(
+        <MemoryRouter>
+          <ProjectPageShell theme="walkability">
+            <CaseStudyHero
+              title="Test Project"
+              framing={<p>Test framing</p>}
+              media={<div>Test media</div>}
+            />
+            <CaseStudySectionCard kicker="01" title="Test Section">
+              <p>Test content</p>
+            </CaseStudySectionCard>
+          </ProjectPageShell>
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText("Test Project")).toBeTruthy();
+      expect(screen.getByText("Test Section")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches user input handling in `WorkWithMe` (sanitization, validation, and client-side rate limiting), which can affect submission UX and edge cases; remaining changes are mostly performance tweaks and new/updated tests.
> 
> **Overview**
> Adds a new `casestudy-components.test.tsx` suite to validate core Case Study components render and produce correct navigation/link attributes, and updates the existing smoke test to assert `WorkWithMe` submission via `toast.success` (including verifying fields reset).
> 
> Hardens the `WorkWithMe` form with input sanitization, stricter validation (max lengths + improved email regex), client-side submission cooldown, and inline error state handling, replacing the previous console-log “submit” behavior.
> 
> Improves image loading controls by adding a `lazy` prop to `ImageWithFallback` (mapped to `loading="lazy"|"eager"`), using it across hero/project pages, and memoizes StormSignal model chart rendering calculations to reduce per-render work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30c8fe550fa81f23df2a1980298e46c508ab7fad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->