### PR TITLE
Fix/case study button order

### DIFF
--- a/docs/design_system/agent_prompt_template.md
+++ b/docs/design_system/agent_prompt_template.md
@@ -11,7 +11,8 @@ Read first:
 3) docs/design_system/README.md
 4) docs/design_system/design_language_contract.md
 5) docs/design_system/page_composition_contract.md
-6) docs/design_system/visual_qa_playbook.md
+6) docs/design_system/project_page_authoring_checklist.md
+7) docs/design_system/visual_qa_playbook.md
 
 Goal:
 - Improve cross-page cohesion while preserving per-project personality.

--- a/docs/design_system/page_composition_contract.md
+++ b/docs/design_system/page_composition_contract.md
@@ -31,21 +31,30 @@ Primary sections (high-level):
 4. CTA/next-step endpoint.
 5. Return navigation.
 
+Supported page patterns:
+
+- `Tokenized Card Shell`: built around `ProjectPageShell` + `CaseStudySectionCard`.
+- `Narrative Systems Layout`: built around custom sections while still using shared case-study primitives.
+
 Composition rules:
 
+- If a page renders `CaseStudyHero`, the page root must provide project theme vars.
+- Use either `ProjectPageShell` or `project-theme` (plus variant when applicable).
 - Back-link treatment should use the shared hero preset.
 - Section cards should map cleanly to `surface_meta`, `surface_content`, or `surface_highlight`.
 - CTA pair semantics should remain consistent across projects.
 - Type roles should be stable regardless of accent theme.
+- Metadata floor is 11px minimum on mobile for labels, lane indices, and connector text.
+- Motion must respect reduced-motion mode; reveal content without translate in that mode.
 
 ## Page-Specific Notes
 
 - `src/app/projects/StormSignal.tsx`
   - Keep structure mostly intact as dense systems reference.
-  - Apply only targeted mechanical alignment updates if needed.
+  - Use shared project primitives for repeated mechanics.
 - `src/app/projects/ReplacementTrap.tsx`
-  - Structural layout iteration is expected next.
   - Keep copy and project personality intact while improving rhythm and modular clarity.
+  - Prefer shared architecture/metric primitives over page-local duplicates.
 - `src/app/projects/WalkabilityIndex.tsx` and `src/app/projects/Bantr.tsx`
   - Maintain tokenized surfaces and CTA mechanics.
   - Prioritize readability and spacing continuity on mobile.

--- a/docs/design_system/project_page_authoring_checklist.md
+++ b/docs/design_system/project_page_authoring_checklist.md
@@ -1,0 +1,36 @@
+# Project Page Authoring Checklist
+
+Use this checklist when creating or refactoring `src/app/projects/*` pages.
+
+## Required Before Merge
+
+1. Theme token contract
+- If the page uses `CaseStudyHero`, ensure the page root includes theme vars.
+- Prefer `ProjectPageShell`.
+- If not using `ProjectPageShell`, root must include `project-theme` and a variant class when defined (for example, `project-theme--replacement`).
+
+2. Shared primitives first
+- Reuse `CaseStudyStatCard` for metric tiles.
+- Reuse `CaseStudySectionHeading` for section headings.
+- Reuse `CaseStudyFlowDiagram` for architecture/process lane diagrams.
+- Do not duplicate these primitives inline unless there is a true one-off requirement.
+
+3. Typography and metadata floor
+- Metadata text must be 11px minimum on mobile.
+- Applies to lane indices, connector labels, kicker labels, and compact status text.
+
+4. Motion accessibility
+- Motion reveals must respect reduced-motion preferences.
+- In reduced-motion mode, content should render without translate animations.
+
+5. Verification
+- TS/JS changes: `npm run lint:js`
+- CSS changes: `npm run lint:css`
+- Then run: `npx tsc --noEmit` and `npm run build`
+
+## Recommended QA Pass
+
+1. Desktop + mobile visual check for section rhythm.
+2. Verify hero back-link remains readable over background layers.
+3. Confirm CTA sizing and hover behavior match shared anatomy.
+4. Check architecture diagrams at mobile width for connector readability.

--- a/src/app/projects/Bantr.tsx
+++ b/src/app/projects/Bantr.tsx
@@ -104,7 +104,7 @@ export function Bantr() {
           </>
         }
         media={
-          <div className="relative h-56 w-full md:h-80">
+          <div className="relative aspect-video w-full">
             <ImageWithFallback
               src="https://images.unsplash.com/photo-1529156069898-49953e39b3ac?auto=format&fit=crop&q=80&w=1600"
               alt="Bantr mobile gameplay"

--- a/src/app/projects/ReplacementTrap.tsx
+++ b/src/app/projects/ReplacementTrap.tsx
@@ -10,7 +10,6 @@ import {
   LineChart,
   CheckCircle2,
 } from "lucide-react";
-import { ImageWithFallback } from "@/app/components/figma/ImageWithFallback";
 import { CaseStudyCtaButton } from "@/app/projects/components/CaseStudyCtaButton";
 import { CaseStudyHero } from "@/app/projects/components/CaseStudyHero";
 import {
@@ -255,16 +254,24 @@ export function ReplacementTrap() {
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_var(--tw-gradient-stops))] from-amber-800/20 via-[#0B0E14] to-[#0B0E14]" />
         }
         media={
-          <div className="relative aspect-video w-full bg-[#151921]">
-            <ImageWithFallback
-              src="https://images.unsplash.com/photo-1621905252507-b35492cc74b4?auto=format&fit=crop&q=80&w=1600"
-              alt="Replacement cycle analysis"
-              className="h-full w-full object-cover opacity-85"
-              lazy={false}
+          <div className="relative aspect-video w-full overflow-hidden bg-[#121722]">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,_rgba(245,158,11,0.14),_transparent_38%),radial-gradient(circle_at_80%_30%,_rgba(251,146,60,0.12),_transparent_36%),linear-gradient(155deg,#141a26_0%,#0f141d_45%,#0b0f17_100%)]" />
+            <div
+              className="absolute inset-0 opacity-20"
+              style={{
+                backgroundImage:
+                  "linear-gradient(to right, rgba(148,163,184,0.12) 1px, transparent 1px), linear-gradient(to bottom, rgba(148,163,184,0.12) 1px, transparent 1px)",
+                backgroundSize: "22px 22px",
+              }}
             />
-            <div className="absolute inset-0 bg-gradient-to-t from-[#0B0E14] via-[#0B0E14]/30 to-transparent opacity-70" />
-            <div className="absolute bottom-0 left-0 right-0 grid gap-2 border-t border-white/10 bg-[#0B0E14]/85 p-4 md:grid-cols-3">
-              <div className="rounded-md border border-white/10 bg-black/20 p-3">
+            <div className="absolute inset-0 bg-gradient-to-t from-[#0B0E14]/85 via-[#0B0E14]/45 to-transparent" />
+            <div className="absolute -right-16 top-6 h-40 w-40 rounded-full bg-amber-400/15 blur-3xl" />
+            <div className="absolute -left-10 bottom-12 h-28 w-28 rounded-full bg-orange-400/10 blur-2xl" />
+            <div className="absolute top-4 right-4 rounded border border-amber-300/20 bg-[#121722]/70 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-amber-300/85">
+              Replacement / Payback Model
+            </div>
+            <div className="absolute bottom-0 left-0 right-0 grid gap-2 border-t border-white/10 bg-[#0B0E14]/92 p-4 md:grid-cols-3">
+              <div className="rounded-md border border-white/10 bg-[#121722]/85 p-3">
                 <p className="font-mono text-xs uppercase tracking-[0.12em] text-amber-300/95">
                   Threshold Rule
                 </p>
@@ -272,7 +279,7 @@ export function ReplacementTrap() {
                   R/P Ratio = lifespan / payback
                 </p>
               </div>
-              <div className="rounded-md border border-white/10 bg-black/20 p-3">
+              <div className="rounded-md border border-white/10 bg-[#121722]/85 p-3">
                 <p className="font-mono text-xs uppercase tracking-[0.12em] text-amber-300/95">
                   Break-even condition
                 </p>
@@ -280,7 +287,7 @@ export function ReplacementTrap() {
                   R/P greater than 1
                 </p>
               </div>
-              <div className="rounded-md border border-white/10 bg-black/20 p-3">
+              <div className="rounded-md border border-white/10 bg-[#121722]/85 p-3">
                 <p className="font-mono text-xs uppercase tracking-[0.12em] text-amber-300/95">
                   Structural loss condition
                 </p>

--- a/src/app/projects/ReplacementTrap.tsx
+++ b/src/app/projects/ReplacementTrap.tsx
@@ -1,10 +1,25 @@
-import { motion as Motion } from "motion/react";
-import { ExternalLink, Github } from "lucide-react";
+import React from "react";
+import { motion as Motion, useReducedMotion } from "motion/react";
+import { useNavigate } from "react-router-dom";
+import {
+  ExternalLink,
+  Github,
+  ArrowLeft,
+  Calculator,
+  Home,
+  TrendingDown,
+  LineChart,
+  CheckCircle2,
+} from "lucide-react";
 import { ImageWithFallback } from "@/app/components/figma/ImageWithFallback";
 import { CaseStudyCtaButton } from "@/app/projects/components/CaseStudyCtaButton";
 import { CaseStudyHero } from "@/app/projects/components/CaseStudyHero";
-import { CaseStudySectionCard } from "@/app/projects/components/CaseStudySectionCard";
-import { ProjectPageShell } from "@/app/projects/components/ProjectPageShell";
+import {
+  CaseStudyFlowDiagram,
+  type CaseStudyFlowLane,
+} from "@/app/projects/components/CaseStudyFlowDiagram";
+import { CaseStudySectionHeading } from "@/app/projects/components/CaseStudySectionHeading";
+import { CaseStudyStatCard } from "@/app/projects/components/CaseStudyStatCard";
 
 const ctas = [
   {
@@ -23,35 +38,224 @@ const ctas = [
 
 const headlineStats = [
   {
-    label: "Systems modeled",
+    label: "Systems Modeled",
     value: "11",
     detail: "Appliances, HVAC, lighting, and insulation",
   },
   {
-    label: "Simulation horizon",
+    label: "Simulation Horizon",
     value: "30 years",
     detail: "Lifecycle cash flow with efficiency decline",
   },
   {
-    label: "Below repayment threshold",
+    label: "Below Repayment Threshold",
     value: "9 / 11",
     detail: "Lifespan falls short of payback in most scenarios",
   },
 ];
 
-export function ReplacementTrap() {
+type FrameworkCard = {
+  title: string;
+  description: React.ReactNode;
+  icon: React.ReactNode;
+  iconBgColor: string;
+  iconColor: string;
+};
+
+const frameworkCards: FrameworkCard[] = [
+  {
+    title: "Threshold Discipline",
+    description:
+      "Every system is evaluated with a deterministic rule: Replacement/Payback (R/P) ratio = lifespan / payback period.",
+    icon: <Calculator className="h-5 w-5" />,
+    iconBgColor: "bg-amber-500/10",
+    iconColor: "text-amber-300",
+  },
+  {
+    title: "Household Reality",
+    description:
+      "Lifecycle economics are modeled under conditions people actually face: aging equipment, uneven savings, and replacement timing shocks.",
+    icon: <Home className="h-5 w-5" />,
+    iconBgColor: "bg-sky-500/10",
+    iconColor: "text-sky-300",
+  },
+  {
+    title: "Loss Detection",
+    description:
+      "The model surfaces structural shortfall risk when systems expire before recovering installed cost.",
+    icon: <TrendingDown className="h-5 w-5" />,
+    iconBgColor: "bg-rose-500/10",
+    iconColor: "text-rose-300",
+  },
+];
+
+const simulationLanes: CaseStudyFlowLane[] = [
+  {
+    title: "Inputs",
+    icon: <Home className="h-4 w-4" />,
+    iconColorClassName: "text-sky-300",
+    nodes: [
+      "Installed Cost + Labor",
+      "Energy Savings Assumptions",
+      "Expected Lifespan Bounds",
+      "Debt / HELOC Terms",
+    ],
+    tightSpacing: true,
+  },
+  {
+    title: "Core Engine",
+    icon: <Calculator className="h-4 w-4" />,
+    iconColorClassName: "text-amber-300",
+    nodes: [
+      "R/P Classification (lifespan / payback)",
+      "30-Year Cash-Flow Simulation",
+      "Efficiency Decline Over Time",
+    ],
+    tightSpacing: true,
+  },
+  {
+    title: "Stress Testing",
+    icon: <LineChart className="h-4 w-4" />,
+    iconColorClassName: "text-orange-300",
+    nodes: [
+      "Monte Carlo Energy Price Paths",
+      "Interest Rate Volatility",
+      "Replacement Timing Shifts",
+    ],
+    tightSpacing: true,
+  },
+  {
+    title: "Decision Outputs",
+    icon: <CheckCircle2 className="h-4 w-4" />,
+    iconColorClassName: "text-emerald-300",
+    nodes: [
+      "Break-even Classification",
+      "Projected Cash Shortfall / Surplus",
+      "Portfolio-Level Risk View",
+    ],
+    tightSpacing: true,
+  },
+];
+
+const simulationTransitions = [
+  "Parameterized System Profile",
+  "Scenario Cash Flows",
+  "Risk-Sorted Outcomes",
+];
+
+type RatioBenchmark = {
+  label: string;
+  ratio: number;
+  note: string;
+};
+
+const ratioBenchmarks: RatioBenchmark[] = [
+  {
+    label: "Central AC (3-ton)",
+    ratio: 0.68,
+    note: "Replacement before payoff in base case.",
+  },
+  {
+    label: "Electric Water Heater",
+    ratio: 0.82,
+    note: "Narrow economics under typical savings.",
+  },
+  {
+    label: "Window Upgrade",
+    ratio: 0.74,
+    note: "Slow recovery relative to upfront cost.",
+  },
+  {
+    label: "Roof Replacement",
+    ratio: 0.91,
+    note: "Near threshold but often below break-even.",
+  },
+  {
+    label: "Attic Insulation",
+    ratio: 1.09,
+    note: "One of the few cases above repayment threshold.",
+  },
+];
+
+function RatioBenchmarkChart({ benchmarks }: { benchmarks: RatioBenchmark[] }) {
+  const maxRatio = React.useMemo(
+    () => Math.max(1.25, ...benchmarks.map((benchmark) => benchmark.ratio)),
+    [benchmarks],
+  );
+
   return (
-    <ProjectPageShell theme="replacement">
+    <div className="rounded-lg border border-white/5 bg-[#0B0E14] p-6 md:p-8">
+      <div className="space-y-5">
+        {benchmarks.map((benchmark) => {
+          const widthPercent = (benchmark.ratio / maxRatio) * 100;
+          const isPassing = benchmark.ratio >= 1;
+          return (
+            <div key={benchmark.label}>
+              <div className="mb-2 flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-sm text-gray-300">{benchmark.label}</p>
+                  <p className="text-xs text-gray-500">{benchmark.note}</p>
+                </div>
+                <span
+                  className={`font-mono text-sm ${isPassing ? "text-emerald-300" : "text-rose-300"}`}
+                >
+                  {benchmark.ratio.toFixed(2)}
+                </span>
+              </div>
+              <div className="relative h-2 overflow-hidden rounded-full bg-white/5">
+                <div
+                  className={`h-full transition-all ${isPassing ? "bg-emerald-400/70" : "bg-rose-400/70"}`}
+                  style={{ width: `${widthPercent}%`, minWidth: "2px" }}
+                />
+                <div
+                  className="absolute top-0 h-full w-px bg-white/60"
+                  style={{ left: `${(1 / maxRatio) * 100}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-8 border-t border-white/10 pt-6">
+        <div className="flex items-center gap-2 text-sm text-amber-300">
+          <LineChart className="h-4 w-4" />
+          <span>Threshold marker at R/P = 1.00 (break-even boundary)</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ReplacementTrap() {
+  const navigate = useNavigate();
+  const shouldReduceMotion = Boolean(useReducedMotion());
+
+  const handleBackToCaseStudies = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    navigate("/");
+    setTimeout(() => {
+      const element = document.querySelector("#page-top");
+      if (element) {
+        const y = element.getBoundingClientRect().top + window.scrollY - 96;
+        window.scrollTo({ top: y, behavior: "smooth" });
+      } else {
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      }
+    }, 100);
+  };
+
+  return (
+    <main className="project-theme project-theme--replacement min-h-screen bg-[var(--project-page-bg)] font-sans text-[var(--project-body-text)] selection:bg-amber-400/20">
       <CaseStudyHero
         title="The Replacement Trap"
         framing={
           <p>
-            A lifecycle cash-flow model testing when home systems die before they
-            repay their cost.
+            A lifecycle cash-flow model testing when residential systems fail
+            before they repay installed cost.
           </p>
         }
         titleClassName="text-4xl leading-tight md:text-6xl"
-        framingClassName="max-w-4xl"
+        framingClassName="max-w-3xl text-xl text-gray-400"
         ctas={ctas.map((cta) => (
           <CaseStudyCtaButton
             key={cta.label}
@@ -62,206 +266,212 @@ export function ReplacementTrap() {
           />
         ))}
         background={
-          <>
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_var(--project-accent-soft),_transparent_45%)]" />
-            <div className="absolute inset-0 bg-gradient-to-b from-transparent via-[var(--project-page-bg)]/30 to-[var(--project-page-bg)]" />
-          </>
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_var(--tw-gradient-stops))] from-amber-800/20 via-[#0B0E14] to-[#0B0E14]" />
         }
         media={
-          <div className="relative h-56 w-full md:h-80">
+          <div className="relative aspect-video w-full bg-[#151921]">
             <ImageWithFallback
               src="https://images.unsplash.com/photo-1621905252507-b35492cc74b4?auto=format&fit=crop&q=80&w=1600"
               alt="Replacement cycle analysis"
-              className="h-full w-full object-cover opacity-70"
+              className="h-full w-full object-cover opacity-85"
               lazy={false}
             />
-            <div className="absolute inset-0 bg-gradient-to-t from-[var(--project-page-bg)] via-[var(--project-page-bg)]/50 to-transparent" />
-            <div className="absolute bottom-0 left-0 right-0 grid gap-2 border-t border-[color:var(--surface-border-default)] bg-[var(--project-page-bg)]/80 p-4 md:grid-cols-3">
-              <div className="rounded-md border border-[color:var(--surface-border-default)] bg-black/20 p-3">
-                <p className="font-mono text-xs uppercase tracking-[0.12em] text-[var(--project-accent-text)]/95">
+            <div className="absolute inset-0 bg-gradient-to-t from-[#0B0E14] via-[#0B0E14]/30 to-transparent opacity-70" />
+            <div className="absolute bottom-0 left-0 right-0 grid gap-2 border-t border-white/10 bg-[#0B0E14]/85 p-4 md:grid-cols-3">
+              <div className="rounded-md border border-white/10 bg-black/20 p-3">
+                <p className="font-mono text-xs uppercase tracking-[0.12em] text-amber-300/95">
                   Threshold Rule
                 </p>
                 <p className="mt-1 text-sm font-semibold text-white">
                   R/P Ratio = lifespan / payback
                 </p>
               </div>
-              <div className="rounded-md border border-[color:var(--surface-border-default)] bg-black/20 p-3">
-                <p className="font-mono text-xs uppercase tracking-[0.12em] text-[var(--project-accent-text)]/95">
+              <div className="rounded-md border border-white/10 bg-black/20 p-3">
+                <p className="font-mono text-xs uppercase tracking-[0.12em] text-amber-300/95">
                   Break-even condition
                 </p>
-                <p className="mt-1 text-sm font-semibold text-white">R/P greater than 1</p>
+                <p className="mt-1 text-sm font-semibold text-white">
+                  R/P greater than 1
+                </p>
               </div>
-              <div className="rounded-md border border-[color:var(--surface-border-default)] bg-black/20 p-3">
-                <p className="font-mono text-xs uppercase tracking-[0.12em] text-[var(--project-accent-text)]/95">
+              <div className="rounded-md border border-white/10 bg-black/20 p-3">
+                <p className="font-mono text-xs uppercase tracking-[0.12em] text-amber-300/95">
                   Structural loss condition
                 </p>
-                <p className="mt-1 text-sm font-semibold text-white">R/P less than 1</p>
+                <p className="mt-1 text-sm font-semibold text-white">
+                  R/P less than 1
+                </p>
               </div>
             </div>
           </div>
         }
       />
 
-      <section className="py-16 md:py-20">
-        <div className="mx-auto w-full max-w-6xl px-6 lg:px-8">
-          <div className="max-w-5xl">
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-              {headlineStats.map((stat) => (
-                <CaseStudySectionCard
-                  key={stat.label}
-                  kicker={stat.label}
-                  title={stat.value}
-                  tone="meta"
-                  titleClassName="text-2xl"
-                  bodyClassName="space-y-0"
+      <section className="border-b border-white/5 bg-[#0B0E14]">
+        <div className="mx-auto max-w-6xl px-6 pb-12 pt-8 lg:px-8">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+            {headlineStats.map((stat) => (
+              <CaseStudyStatCard
+                key={stat.label}
+                label={stat.label}
+                value={stat.value}
+                subtext={stat.detail}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-[#0B0E14] py-12 md:py-20">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <CaseStudySectionHeading
+            title="The Context"
+            subtitle="Residential upgrades are often sold as investments, but replacement cycles and financing frictions can prevent cost recovery."
+            subtitleClassName="max-w-3xl"
+          />
+          <div className="prose prose-invert max-w-none text-gray-400">
+            <p className="text-base md:text-lg">
+              Most homeowner decisions are made under uncertainty: variable
+              utility prices, uneven equipment performance, and debt-funded
+              replacement decisions. Simple payback estimates ignore this
+              lifecycle pressure.
+            </p>
+            <p className="mt-6 text-base md:text-lg">
+              The Replacement Trap reframes the question with a structural
+              threshold: does a system survive long enough to repay itself
+              before it has to be replaced?
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-y border-white/5 bg-[#11141a] py-12 md:py-20">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <CaseStudySectionHeading title="Analytical Doctrine" />
+          <p className="mb-8 max-w-3xl text-base leading-relaxed text-gray-400 md:mb-12">
+            The model favors inspectable economics over abstract optimism. Each
+            outcome is tied to explicit assumptions, deterministic threshold
+            logic, and stress-tested scenarios.
+          </p>
+          <div className="grid gap-4 md:grid-cols-3 md:gap-6">
+            {frameworkCards.map((card, idx) => {
+              const cardClasses =
+                "rounded-sm border border-white/5 bg-[#151921] p-4 md:p-6";
+
+              const cardContent = (
+                <>
+                  <div
+                    className={`mb-4 flex h-10 w-10 items-center justify-center rounded-sm ${card.iconBgColor} ${card.iconColor}`}
+                  >
+                    {card.icon}
+                  </div>
+                  <h3 className="mb-2 font-bold text-white">{card.title}</h3>
+                  <p className="text-sm leading-relaxed text-gray-400">
+                    {card.description}
+                  </p>
+                </>
+              );
+
+              if (shouldReduceMotion) {
+                return (
+                  <div key={card.title} className={cardClasses}>
+                    {cardContent}
+                  </div>
+                );
+              }
+
+              return (
+                <Motion.div
+                  key={card.title}
+                  initial={{ opacity: 0, y: 10 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true, amount: 0.4 }}
+                  transition={{ duration: 0.3, delay: idx * 0.06 }}
+                  className={cardClasses}
                 >
-                  <p className="text-sm text-[var(--project-muted-text)]">{stat.detail}</p>
-                </CaseStudySectionCard>
-              ))}
-            </div>
+                  {cardContent}
+                </Motion.div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
 
-            <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-3">
-              <Motion.div
-                initial={{ opacity: 0.95, y: 14 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.35 }}
-              >
-                <CaseStudySectionCard kicker="01" title="Why This Matters" className="h-full">
-                  <p className="leading-relaxed">
-                    Most major home systems are framed as "investments."
-                  </p>
-                  <p className="leading-relaxed">
-                    This project tests that claim structurally using a simple
-                    decision rule: how long the system lasts relative to how long
-                    it takes to pay for itself.
-                  </p>
-                  <div className="rounded-md border border-[color:var(--surface-border-default)] bg-[var(--surface-meta-bg)] p-3 font-mono text-sm text-[var(--project-accent-text)]">
-                    R/P Ratio (Replacement / Payback): lifespan / payback period
-                  </div>
-                  <div>
-                    <p className="mb-2 leading-relaxed">In plain terms:</p>
-                    <ul className="space-y-2">
-                      <li className="flex gap-3">
-                        <span className="text-[var(--project-accent-text)]">-</span>
-                        <span>
-                          If the ratio is <strong className="text-white">greater than 1</strong>,
-                          the system survives long enough to earn back its
-                          installed cost.
-                        </span>
-                      </li>
-                      <li className="flex gap-3">
-                        <span className="text-[var(--project-accent-text)]">-</span>
-                        <span>
-                          If the ratio is <strong className="text-white">less than 1</strong>,
-                          it reaches end-of-life before fully repaying its
-                          capital.
-                        </span>
-                      </li>
-                    </ul>
-                  </div>
-                  <p className="leading-relaxed">
-                    When lifespan is less than payback, each replacement cycle
-                    resets capital before recovery, creating structural loss
-                    instead of compounding return. This was illustrated by
-                    lifespan falling short of payback in 9 of 11 modeled
-                    scenarios.
-                  </p>
-                </CaseStudySectionCard>
-              </Motion.div>
-
-              <Motion.div
-                initial={{ opacity: 0.95, y: 14 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.35, delay: 0.05 }}
-              >
-                <CaseStudySectionCard kicker="02" title="What I Built" className="h-full">
-                  <p className="leading-relaxed">
-                    A lifecycle cash-flow model covering 11 common residential
-                    systems (appliances, HVAC, lighting, insulation).
-                  </p>
-                  <div>
-                    <p className="mb-3 leading-relaxed">The model includes:</p>
-                    <ul className="space-y-2">
-                      <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>An R/P threshold rule (lifespan / payback)</span></li>
-                      <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>A 30-year cash-flow simulation that accounts for efficiency decline over time</span></li>
-                      <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>HELOC financing scenarios to model replacements paid for with debt</span></li>
-                      <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>Monte Carlo stress tests under changing energy prices and interest rates</span></li>
-                      <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>A modular Python codebase with validation tests and reproducible outputs</span></li>
-                    </ul>
-                  </div>
-                  <div>
-                    <p className="mb-3 leading-relaxed">Model boundaries:</p>
-                    <ul className="space-y-2">
-                      <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>Direct, measurable cash costs and savings only</span></li>
-                      <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>Installation labor included in capital cost</span></li>
-                      <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>Explicit lifespan assumptions with bounded volatility</span></li>
-                    </ul>
-                  </div>
-                  <p className="leading-relaxed">
-                    Comfort, carbon, and resilience premiums are excluded to keep
-                    the model focused on cash economics.
-                  </p>
-                  <div className="rounded-md border border-[color:var(--surface-border-default)] bg-[var(--surface-meta-bg)] p-4">
-                    <p className="font-mono text-xs uppercase tracking-[0.12em] text-[var(--project-accent-text)]/95">
-                      Example
-                    </p>
-                    <p className="mt-2 leading-relaxed">
-                      A standard 3-ton AC costing about $9,500 and saving about
-                      $200 per year reaches end-of-life around year 13, leaving
-                      a multi-thousand-dollar shortfall before payback.
-                    </p>
-                  </div>
-                </CaseStudySectionCard>
-              </Motion.div>
-
-              <Motion.div
-                initial={{ opacity: 0.95, y: 14 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.35, delay: 0.1 }}
-              >
-                <CaseStudySectionCard kicker="03" title="Explore the Work" className="h-full" tone="highlight">
-                  <p className="leading-relaxed">
-                    The essay explains the intuition behind the Replacement /
-                    Payback threshold and the broader housing implications.
-                  </p>
-                  <p className="leading-relaxed">The repository exposes the model itself:</p>
-                  <ul className="space-y-2">
-                    <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>Full structure and assumptions</span></li>
-                    <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>Test coverage and validation logic</span></li>
-                    <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>HELOC financing scenarios</span></li>
-                    <li className="flex gap-3"><span className="text-[var(--project-accent-text)]">-</span><span>Monte Carlo stress tests</span></li>
-                  </ul>
-
-                  <div className="flex flex-col gap-3 pt-1">
-                    {ctas.map((cta) => (
-                      <CaseStudyCtaButton
-                        key={`bottom-${cta.label}`}
-                        label={cta.label}
-                        href={cta.href}
-                        icon={cta.icon}
-                        variant={cta.variant}
-                      />
-                    ))}
-                  </div>
-
-                  <p className="leading-relaxed">
-                    If you read one section, start with the R/P classification
-                    results and the cash-flow outputs.
-                  </p>
-                  <p className="leading-relaxed">
-                    All assumptions, boundaries, and mechanics are inspectable.
-                    This model is designed to withstand scrutiny, not just
-                    summarize a thesis.
-                  </p>
-                </CaseStudySectionCard>
-              </Motion.div>
+      <section className="bg-[#0B0E14] py-10 md:py-12">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <CaseStudySectionHeading
+            title="Model Architecture"
+            subtitle="A constrained simulation pipeline: standardized inputs, deterministic thresholds, scenario stress testing, and risk-ranked outputs."
+            subtitleClassName="max-w-3xl"
+          />
+          <div className="mt-8 md:mt-6">
+            <div className="relative rounded-lg border border-white/10 bg-[#151921] p-3 md:p-3 lg:p-6">
+              <div
+                className="absolute inset-0 rounded-lg opacity-5"
+                style={{
+                  backgroundImage:
+                    "radial-gradient(circle, currentColor 1px, transparent 1px)",
+                  backgroundSize: "24px 24px",
+                }}
+              />
+              <CaseStudyFlowDiagram
+                lanes={simulationLanes}
+                transitions={simulationTransitions}
+                accentTextClassName="text-amber-300"
+                accentBorderClassName="border-amber-300/40"
+                fallbackFinalOutputLabel="Actionable Scenario Review"
+              />
             </div>
           </div>
         </div>
       </section>
-    </ProjectPageShell>
+
+      <section className="border-y border-white/5 bg-[#151921] py-12 md:py-20">
+        <div className="mx-auto max-w-5xl px-6 lg:px-8">
+          <div className="grid items-center gap-8 md:grid-cols-2 md:gap-12">
+            <div>
+              <h3 className="mb-2 font-mono text-sm uppercase tracking-widest text-amber-300">
+                Key Structural Finding
+              </h3>
+              <h2 className="mb-4 text-2xl font-bold text-white md:mb-6 md:text-3xl">
+                Replacement Cycles Can Outrun Payback
+              </h2>
+              <div className="space-y-4 leading-relaxed text-gray-400 md:space-y-6">
+                <p>
+                  In 9 of 11 modeled systems, base-case lifespan is shorter than
+                  payback. That means capital is redeployed before prior spending
+                  is recovered.
+                </p>
+                <p>
+                  Financing pressure amplifies the effect. HELOC-funded
+                  replacements can increase total shortfall even when annual
+                  utility savings look attractive.
+                </p>
+                <p>
+                  The implication is not that upgrades never make sense. It is
+                  that break-even should be treated as a lifecycle probability
+                  problem, not a headline-savings claim.
+                </p>
+              </div>
+            </div>
+
+            <RatioBenchmarkChart benchmarks={ratioBenchmarks} />
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-white/5 bg-[#0B0E14] py-12">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <a
+            href="/#page-top"
+            onClick={handleBackToCaseStudies}
+            className="inline-flex items-center gap-2 text-sm font-medium text-gray-500 transition-colors hover:text-white"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Case Studies
+          </a>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/src/app/projects/ReplacementTrap.tsx
+++ b/src/app/projects/ReplacementTrap.tsx
@@ -14,7 +14,7 @@ const ctas = [
     variant: "primary" as const,
   },
   {
-    label: "View on GitHub",
+    label: "View on Github",
     href: "https://github.com/ghgeist/replacement_trap",
     icon: <Github className="h-4 w-4" />,
     variant: "secondary" as const,
@@ -265,4 +265,3 @@ export function ReplacementTrap() {
     </ProjectPageShell>
   );
 }
-

--- a/src/app/projects/ReplacementTrap.tsx
+++ b/src/app/projects/ReplacementTrap.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { motion as Motion, useReducedMotion } from "motion/react";
-import { useNavigate } from "react-router-dom";
 import {
   ExternalLink,
   Github,
@@ -20,6 +19,7 @@ import {
 } from "@/app/projects/components/CaseStudyFlowDiagram";
 import { CaseStudySectionHeading } from "@/app/projects/components/CaseStudySectionHeading";
 import { CaseStudyStatCard } from "@/app/projects/components/CaseStudyStatCard";
+import { useBackToCaseStudies } from "@/app/projects/hooks/useBackToCaseStudies";
 
 const ctas = [
   {
@@ -227,22 +227,8 @@ function RatioBenchmarkChart({ benchmarks }: { benchmarks: RatioBenchmark[] }) {
 }
 
 export function ReplacementTrap() {
-  const navigate = useNavigate();
   const shouldReduceMotion = Boolean(useReducedMotion());
-
-  const handleBackToCaseStudies = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
-    navigate("/");
-    setTimeout(() => {
-      const element = document.querySelector("#page-top");
-      if (element) {
-        const y = element.getBoundingClientRect().top + window.scrollY - 96;
-        window.scrollTo({ top: y, behavior: "smooth" });
-      } else {
-        window.scrollTo({ top: 0, behavior: "smooth" });
-      }
-    }, 100);
-  };
+  const handleBackToCaseStudies = useBackToCaseStudies();
 
   return (
     <main className="project-theme project-theme--replacement min-h-screen bg-[var(--project-page-bg)] font-sans text-[var(--project-body-text)] selection:bg-amber-400/20">

--- a/src/app/projects/ReplacementTrap.tsx
+++ b/src/app/projects/ReplacementTrap.tsx
@@ -241,7 +241,7 @@ export function ReplacementTrap() {
           </p>
         }
         titleClassName="text-4xl leading-tight md:text-6xl"
-        framingClassName="max-w-3xl text-xl text-gray-400"
+        framingClassName="max-w-3xl text-xl md:text-xl text-gray-400"
         ctas={ctas.map((cta) => (
           <CaseStudyCtaButton
             key={cta.label}

--- a/src/app/projects/ReplacementTrap.tsx
+++ b/src/app/projects/ReplacementTrap.tsx
@@ -267,7 +267,7 @@ export function ReplacementTrap() {
             <div className="absolute inset-0 bg-gradient-to-t from-[#0B0E14]/85 via-[#0B0E14]/45 to-transparent" />
             <div className="absolute -right-16 top-6 h-40 w-40 rounded-full bg-amber-400/15 blur-3xl" />
             <div className="absolute -left-10 bottom-12 h-28 w-28 rounded-full bg-orange-400/10 blur-2xl" />
-            <div className="absolute top-4 right-4 rounded border border-amber-300/20 bg-[#121722]/70 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-amber-300/85">
+            <div className="absolute top-4 right-4 rounded border border-amber-300/20 bg-[#121722]/70 px-2 py-1 font-mono text-[11px] uppercase tracking-[0.14em] text-amber-300/85">
               Replacement / Payback Model
             </div>
             <div className="absolute bottom-0 left-0 right-0 grid gap-2 border-t border-white/10 bg-[#0B0E14]/92 p-4 md:grid-cols-3">
@@ -300,7 +300,7 @@ export function ReplacementTrap() {
         }
       />
 
-      <section className="border-b border-white/5 bg-[#0B0E14]">
+      <section className="border-b border-white/5 bg-[var(--project-page-bg)]">
         <div className="mx-auto max-w-6xl px-6 pb-12 pt-8 lg:px-8">
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
             {headlineStats.map((stat) => (
@@ -315,7 +315,7 @@ export function ReplacementTrap() {
         </div>
       </section>
 
-      <section className="bg-[#0B0E14] py-12 md:py-20">
+      <section className="bg-[var(--project-page-bg)] py-12 md:py-20">
         <div className="mx-auto max-w-6xl px-6 lg:px-8">
           <CaseStudySectionHeading
             title="The Context"
@@ -390,7 +390,7 @@ export function ReplacementTrap() {
         </div>
       </section>
 
-      <section className="bg-[#0B0E14] py-10 md:py-12">
+      <section className="bg-[var(--project-page-bg)] py-10 md:py-12">
         <div className="mx-auto max-w-6xl px-6 lg:px-8">
           <CaseStudySectionHeading
             title="Model Architecture"
@@ -453,7 +453,7 @@ export function ReplacementTrap() {
         </div>
       </section>
 
-      <section className="border-t border-white/5 bg-[#0B0E14] py-12">
+      <section className="border-t border-white/5 bg-[var(--project-page-bg)] py-12">
         <div className="mx-auto max-w-6xl px-6 lg:px-8">
           <a
             href="/#page-top"

--- a/src/app/projects/StormSignal.tsx
+++ b/src/app/projects/StormSignal.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import {
   ExternalLink,
   Github,
@@ -21,6 +20,7 @@ import {
 } from "@/app/projects/components/CaseStudyFlowDiagram";
 import { CaseStudySectionHeading } from "@/app/projects/components/CaseStudySectionHeading";
 import { CaseStudyStatCard } from "@/app/projects/components/CaseStudyStatCard";
+import { useBackToCaseStudies } from "@/app/projects/hooks/useBackToCaseStudies";
 
 const ctas = [
   {
@@ -192,21 +192,7 @@ function ModelComparisonChart({ models }: { models: ModelComparison[] }) {
 }
 
 export function StormSignal() {
-  const navigate = useNavigate();
-
-  const handleBackToCaseStudies = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
-    navigate("/");
-    setTimeout(() => {
-      const element = document.querySelector("#page-top");
-      if (element) {
-        const y = element.getBoundingClientRect().top + window.scrollY - 96;
-        window.scrollTo({ top: y, behavior: "smooth" });
-      } else {
-        window.scrollTo({ top: 0, behavior: "smooth" });
-      }
-    }, 100);
-  };
+  const handleBackToCaseStudies = useBackToCaseStudies();
 
   return (
     <main className="project-theme min-h-screen bg-[#0B0E14] font-sans selection:bg-blue-500/30">

--- a/src/app/projects/StormSignal.tsx
+++ b/src/app/projects/StormSignal.tsx
@@ -1,28 +1,23 @@
 import React from "react";
 import { motion as Motion } from "motion/react";
-import { Link, useNavigate } from "react-router-dom";
-import { ExternalLink, Github, ArrowRight, ArrowLeft, CheckCircle2, Zap, Database, Shield, Globe, Brain, Users } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { ExternalLink, Github, ArrowLeft, CheckCircle2, Zap, Database, Shield, Globe, Brain, Users } from "lucide-react";
 import { ImageWithFallback } from "@/app/components/figma/ImageWithFallback";
+import { CaseStudyCtaButton } from "@/app/projects/components/CaseStudyCtaButton";
+import { CaseStudyHero } from "@/app/projects/components/CaseStudyHero";
 
-type CtaLink = {
-  label: string;
-  href: string;
-  icon: React.ReactNode;
-  variant: "primary" | "secondary";
-};
-
-const ctas: CtaLink[] = [
+const ctas = [
   {
     label: "Live Demo",
     href: "https://storm-signal.replit.app/",
-    icon: <ExternalLink className="w-4 h-4" />,
-    variant: "primary",
+    icon: <ExternalLink className="h-4 w-4" />,
+    variant: "primary" as const,
   },
   {
-    label: "View Source",
+    label: "View on Github",
     href: "https://github.com/ghgeist/disaster_response_project",
-    icon: <Github className="w-4 h-4" />,
-    variant: "secondary",
+    icon: <Github className="h-4 w-4" />,
+    variant: "secondary" as const,
   },
 ];
 
@@ -122,28 +117,6 @@ const modelComparisons: ModelComparison[] = [
   { label: "LR (with vocabulary filters)", sizeMB: 13.0, color: "blue" },
   { label: "LR (15K features)", sizeMB: 4.5, color: "green" },
 ];
-
-function CtaButton({ label, href, icon, variant }: CtaLink) {
-  const base =
-    "inline-flex items-center justify-center gap-2 px-5 py-2.5 text-sm font-medium transition-all rounded-sm";
-  const styles =
-    variant === "primary"
-      ? "bg-blue-600 text-white hover:bg-blue-500 shadow-lg shadow-blue-900/20"
-      : "bg-white/5 text-gray-200 border border-white/10 hover:bg-white/10 hover:border-white/20";
-
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noreferrer"
-      className={`${base} ${styles}`}
-    >
-      {icon}
-      <span>{label}</span>
-      {variant === "primary" && <ArrowRight className="w-4 h-4 opacity-70" />}
-    </a>
-  );
-}
 
 function StatCard({ label, value, subtext }: { label: string; value: string; subtext: string }) {
   return (
@@ -288,21 +261,21 @@ function ArchitectureMobile() {
   );
 }
 
-function ModelComparisonChart({ models }: { models: ModelComparison[] }) {
-  const colorConfig: Record<ModelComparison["color"], { bg: string; text: string }> = {
-    red: { bg: "bg-rose-400/70", text: "text-rose-300/95" },
-    yellow: { bg: "bg-amber-400/70", text: "text-amber-300/90" },
-    blue: { bg: "bg-sky-400/70", text: "text-sky-300/90" },
-    green: { bg: "bg-emerald-400/70", text: "text-emerald-300/90" },
-  };
+const MODEL_COLOR_CONFIG: Record<ModelComparison["color"], { bg: string; text: string }> = {
+  red: { bg: "bg-rose-400/70", text: "text-rose-300/95" },
+  yellow: { bg: "bg-amber-400/70", text: "text-amber-300/90" },
+  blue: { bg: "bg-sky-400/70", text: "text-sky-300/90" },
+  green: { bg: "bg-emerald-400/70", text: "text-emerald-300/90" },
+};
 
+function ModelComparisonChart({ models }: { models: ModelComparison[] }) {
   const maxModelSize = 1000;
 
   // Memoize calculations to avoid recalculation on every render
   const modelData = React.useMemo(() => {
     return models.map((model) => {
       const widthPercent = (model.sizeMB / maxModelSize) * 100;
-      const colors = colorConfig[model.color];
+      const colors = MODEL_COLOR_CONFIG[model.color];
       return {
         ...model,
         widthPercent,
@@ -363,55 +336,41 @@ export function StormSignal() {
   return (
     <main className="bg-[#0B0E14] min-h-screen font-sans selection:bg-blue-500/30">
       {/* Hero Section */}
-      <header className="relative pt-20 pb-12 md:pt-32 md:pb-16 overflow-hidden border-b border-white/5">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_var(--tw-gradient-stops))] from-blue-900/20 via-[#0B0E14] to-[#0B0E14]" />
-        
-        <div className="relative max-w-6xl mx-auto px-6 lg:px-8">
-          <Motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-            className="grid lg:grid-cols-2 gap-8 md:gap-12 items-center"
-          >
-            <div>
-              <Link
-                to="/"
-                className="inline-flex items-center gap-2 text-gray-500 hover:text-white transition-colors text-sm font-medium mb-8"
-              >
-                <ArrowLeft className="w-4 h-4" />
-                Back to Case Studies
-              </Link>
-              
-              <h1 className="text-4xl md:text-6xl font-bold text-white tracking-tight leading-tight mb-8">
-                Storm Signal
-              </h1>
-              <p className="text-xl text-gray-400 leading-relaxed mb-8 max-w-xl">
-                A disaster-response monitoring dashboard that routes high-volume messages into actionable categories — using a compact, auditable ML pipeline built for speed and offline deployment.
-              </p>
-              
-              <div className="flex flex-wrap gap-4">
-                {ctas.map((cta) => (
-                  <CtaButton key={cta.label} {...cta} />
-                ))}
-              </div>
-            </div>
-
-            <div className="relative">
-              <div className="rounded-lg overflow-hidden border border-white/10 bg-[#151921] shadow-2xl shadow-black/50 aspect-video group">
-                <ImageWithFallback
-                  src="https://images.unsplash.com/photo-1550751827-4bd374c3f58b?auto=format&fit=crop&q=80&w=1600" 
-                  alt="Storm Signal Dashboard"
-                  className="w-full h-full object-cover opacity-90 transition-opacity group-hover:opacity-100"
-                  lazy={false}
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-[#0B0E14] via-transparent to-transparent opacity-60" />
-              </div>
-              {/* Decorative background element */}
-              <div className="absolute -inset-4 bg-blue-500/5 blur-3xl -z-10 rounded-full" />
-            </div>
-          </Motion.div>
-        </div>
-      </header>
+      <CaseStudyHero
+        title="Storm Signal"
+        framing={
+          <p>
+            A disaster-response monitoring dashboard that routes high-volume
+            messages into actionable categories - using a compact, auditable ML
+            pipeline built for speed and offline deployment.
+          </p>
+        }
+        titleClassName="text-4xl leading-tight md:text-6xl"
+        framingClassName="max-w-3xl text-xl text-gray-400"
+        ctas={ctas.map((cta) => (
+          <CaseStudyCtaButton
+            key={cta.label}
+            label={cta.label}
+            href={cta.href}
+            icon={cta.icon}
+            variant={cta.variant}
+          />
+        ))}
+        background={
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_var(--tw-gradient-stops))] from-blue-900/20 via-[#0B0E14] to-[#0B0E14]" />
+        }
+        media={
+          <div className="relative aspect-video w-full bg-[#151921]">
+            <ImageWithFallback
+              src="https://images.unsplash.com/photo-1550751827-4bd374c3f58b?auto=format&fit=crop&q=80&w=1600"
+              alt="Storm Signal Dashboard"
+              className="h-full w-full object-cover opacity-90"
+              lazy={false}
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-[#0B0E14] via-transparent to-transparent opacity-60" />
+          </div>
+        }
+      />
 
       {/* Metrics Grid */}
       <section className="border-b border-white/5 bg-[#0B0E14]">

--- a/src/app/projects/StormSignal.tsx
+++ b/src/app/projects/StormSignal.tsx
@@ -206,7 +206,7 @@ export function StormSignal() {
           </p>
         }
         titleClassName="text-4xl leading-tight md:text-6xl"
-        framingClassName="max-w-3xl text-xl text-gray-400"
+        framingClassName="max-w-3xl text-xl md:text-xl text-gray-400"
         ctas={ctas.map((cta) => (
           <CaseStudyCtaButton
             key={cta.label}

--- a/src/app/projects/StormSignal.tsx
+++ b/src/app/projects/StormSignal.tsx
@@ -1,10 +1,26 @@
 import React from "react";
-import { motion as Motion } from "motion/react";
 import { useNavigate } from "react-router-dom";
-import { ExternalLink, Github, ArrowLeft, CheckCircle2, Zap, Database, Shield, Globe, Brain, Users } from "lucide-react";
+import {
+  ExternalLink,
+  Github,
+  ArrowLeft,
+  CheckCircle2,
+  Zap,
+  Database,
+  Shield,
+  Globe,
+  Brain,
+  Users,
+} from "lucide-react";
 import { ImageWithFallback } from "@/app/components/figma/ImageWithFallback";
 import { CaseStudyCtaButton } from "@/app/projects/components/CaseStudyCtaButton";
 import { CaseStudyHero } from "@/app/projects/components/CaseStudyHero";
+import {
+  CaseStudyFlowDiagram,
+  type CaseStudyFlowLane,
+} from "@/app/projects/components/CaseStudyFlowDiagram";
+import { CaseStudySectionHeading } from "@/app/projects/components/CaseStudySectionHeading";
+import { CaseStudyStatCard } from "@/app/projects/components/CaseStudyStatCard";
 
 const ctas = [
   {
@@ -21,25 +37,17 @@ const ctas = [
   },
 ];
 
-type ArchitectureLane = {
-  title: string;
-  icon: React.ReactNode;
-  iconColor: string;
-  nodes: string[];
-  tightSpacing?: boolean;
-};
-
-const architectureLanes: ArchitectureLane[] = [
+const architectureLanes: CaseStudyFlowLane[] = [
   {
     title: "External Data Sources",
-    icon: <Globe className="w-4 h-4" />,
-    iconColor: "text-blue-400",
+    icon: <Globe className="h-4 w-4" />,
+    iconColorClassName: "text-blue-400",
     nodes: ["High-Volume Social Data Streams"],
   },
   {
     title: "Machine Learning",
-    icon: <Brain className="w-4 h-4" />,
-    iconColor: "text-pink-400",
+    icon: <Brain className="h-4 w-4" />,
+    iconColorClassName: "text-pink-400",
     nodes: [
       "Threshold Tuning (Recall-Optimized)",
       "Sparse Text Classifier (TF-IDF + Logistic Regression)",
@@ -49,8 +57,8 @@ const architectureLanes: ArchitectureLane[] = [
   },
   {
     title: "Monitoring Dashboard",
-    icon: <Zap className="w-4 h-4" />,
-    iconColor: "text-orange-400",
+    icon: <Zap className="h-4 w-4" />,
+    iconColorClassName: "text-orange-400",
     nodes: [
       "Signal Aggregation",
       "Live Feed Priority Tagged Signals",
@@ -61,8 +69,8 @@ const architectureLanes: ArchitectureLane[] = [
   },
   {
     title: "Action Layer",
-    icon: <Users className="w-4 h-4" />,
-    iconColor: "text-red-400",
+    icon: <Users className="h-4 w-4" />,
+    iconColorClassName: "text-red-400",
     nodes: ["Human Triage & Dispatch"],
   },
 ];
@@ -84,22 +92,29 @@ type DesignDoctrineCard = {
 const designDoctrineCards: DesignDoctrineCard[] = [
   {
     title: "Controlled Routing",
-    description: <>Prioritizing deterministic categorization over generative flexibility. Responders need to know exactly <em>where</em> a message goes.</>,
-    icon: <Database className="w-5 h-5" />,
+    description: (
+      <>
+        Prioritizing deterministic categorization over generative flexibility.
+        Responders need to know exactly <em>where</em> a message goes.
+      </>
+    ),
+    icon: <Database className="h-5 w-5" />,
     iconBgColor: "bg-blue-500/10",
     iconColor: "text-blue-400",
   },
   {
     title: "Auditability",
-    description: "System decisions must be traceable. Explicit thresholds and hierarchy controls ensure behavior is predictable.",
-    icon: <Shield className="w-5 h-5" />,
+    description:
+      "System decisions must be traceable. Explicit thresholds and hierarchy controls ensure behavior is predictable.",
+    icon: <Shield className="h-5 w-5" />,
     iconBgColor: "bg-purple-500/10",
     iconColor: "text-purple-400",
   },
   {
     title: "Human-in-the-loop",
-    description: "Signals inform judgment; they do not replace it. The system exposes confidence levels to help operators make fast, verified decisions.",
-    icon: <CheckCircle2 className="w-5 h-5" />,
+    description:
+      "Signals inform judgment; they do not replace it. The system exposes confidence levels to help operators make fast, verified decisions.",
+    icon: <CheckCircle2 className="h-5 w-5" />,
     iconBgColor: "bg-green-500/10",
     iconColor: "text-green-400",
   },
@@ -118,150 +133,10 @@ const modelComparisons: ModelComparison[] = [
   { label: "LR (15K features)", sizeMB: 4.5, color: "green" },
 ];
 
-function StatCard({ label, value, subtext }: { label: string; value: string; subtext: string }) {
-  return (
-    <div className="bg-[#151921] border border-white/5 p-4 md:p-5 rounded-sm">
-      <div className="text-gray-500 text-xs font-mono uppercase tracking-wider mb-1">{label}</div>
-      <div className="text-xl md:text-2xl font-bold text-white mb-1">{value}</div>
-      <div className="text-gray-400 text-sm">{subtext}</div>
-    </div>
-  );
-}
-
-function SectionHeading({ title, subtitle }: { title: string; subtitle?: string }) {
-  return (
-    <div className="mb-6 md:mb-8">
-      <h2 className="text-2xl md:text-3xl font-bold text-white tracking-tight">{title}</h2>
-      {subtitle && <p className="mt-3 text-base md:text-lg text-gray-400 max-w-2xl leading-relaxed">{subtitle}</p>}
-    </div>
-  );
-}
-
-function Node({ text }: { text: string }) {
-  return (
-    <div className="w-full bg-white/[0.03] border border-white/10 rounded-md px-3 py-2 md:px-3 md:py-2 text-center">
-      <p className="text-[13px] md:text-[13px] text-gray-300 leading-normal md:leading-snug">{text}</p>
-    </div>
-  );
-}
-
-function Lane({
-  index,
-  title,
-  icon,
-  iconColor,
-  nodes,
-  nextLabel,
-  tightSpacing = false,
-}: {
-  index: number;
-  title: string;
-  icon: React.ReactNode;
-  iconColor: string;
-  nodes: string[];
-  nextLabel?: string;
-  tightSpacing?: boolean;
-}) {
-  const laneNumber = String(index + 1).padStart(2, "0");
-
-  return (
-    <div className="bg-white/[0.02] border border-white/10 rounded-lg p-3.5 md:p-3 flex flex-col h-full min-h-0 sm:min-h-[180px] md:min-h-[170px]">
-      <div className="flex items-start justify-between gap-2 mb-3 md:mb-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <div className={`${iconColor} flex-shrink-0`}>
-            {icon}
-          </div>
-          <h3 className="text-xs md:text-sm font-semibold text-white">{title}</h3>
-        </div>
-        <span className="text-[10px] font-mono text-blue-400 border border-blue-400/25 rounded px-1.5 py-0.5">
-          {laneNumber}
-        </span>
-      </div>
-
-      <div className="flex-1 flex flex-col justify-start">
-        <div className={`w-full max-w-full md:max-w-[240px] mx-auto ${tightSpacing ? "space-y-1" : "space-y-2"}`}>
-          {nodes.map((text, idx) => (
-            <Node key={idx} text={text} />
-          ))}
-        </div>
-      </div>
-
-      <div className="hidden sm:block mt-2 md:mt-1.5 pt-2 md:pt-1.5 border-t border-white/10">
-        {nextLabel ? (
-          <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-0.5 text-[11px] text-center">
-            <span className="font-mono uppercase tracking-wide text-blue-400">Output:</span>
-            <span className="text-blue-400">{nextLabel}</span>
-          </div>
-        ) : (
-          <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-0.5 text-[11px] text-center">
-            <span className="font-mono uppercase tracking-wide text-blue-400">Output:</span>
-            <span className="text-blue-400">Responder Dispatch</span>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function MobileFlowConnector({ label }: { label: string }) {
-  return (
-    <div className="flex items-center justify-center gap-2 py-1 text-[11px] text-center">
-      <span className="font-mono uppercase tracking-wide text-blue-400">Output:</span>
-      <span className="text-blue-400">{label}</span>
-    </div>
-  );
-}
-
-function AnimatedLane({ lane, idx }: { lane: ArchitectureLane; idx: number }) {
-  return (
-    <Motion.div
-      initial={{ opacity: 0, y: 10 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.3 }}
-      transition={{ duration: 0.35, delay: idx * 0.08 }}
-      className="h-full"
-    >
-      <Lane
-        index={idx}
-        title={lane.title}
-        icon={lane.icon}
-        iconColor={lane.iconColor}
-        nodes={lane.nodes}
-        nextLabel={architectureTransitions[idx]}
-        tightSpacing={lane.tightSpacing}
-      />
-    </Motion.div>
-  );
-}
-
-function ArchitectureDesktopTablet() {
-  return (
-    <div className="relative hidden sm:block">
-      <div className="relative grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 md:gap-3">
-        {architectureLanes.map((lane, idx) => (
-          <AnimatedLane key={idx} lane={lane} idx={idx} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ArchitectureMobile() {
-  return (
-    <div className="relative sm:hidden">
-      <div className="space-y-2">
-        {architectureLanes.map((lane, idx) => (
-          <React.Fragment key={idx}>
-            <AnimatedLane lane={lane} idx={idx} />
-            {idx < architectureTransitions.length && <MobileFlowConnector label={architectureTransitions[idx]} />}
-          </React.Fragment>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-const MODEL_COLOR_CONFIG: Record<ModelComparison["color"], { bg: string; text: string }> = {
+const MODEL_COLOR_CONFIG: Record<
+  ModelComparison["color"],
+  { bg: string; text: string }
+> = {
   red: { bg: "bg-rose-400/70", text: "text-rose-300/95" },
   yellow: { bg: "bg-amber-400/70", text: "text-amber-300/90" },
   blue: { bg: "bg-sky-400/70", text: "text-sky-300/90" },
@@ -271,7 +146,6 @@ const MODEL_COLOR_CONFIG: Record<ModelComparison["color"], { bg: string; text: s
 function ModelComparisonChart({ models }: { models: ModelComparison[] }) {
   const maxModelSize = 1000;
 
-  // Memoize calculations to avoid recalculation on every render
   const modelData = React.useMemo(() => {
     return models.map((model) => {
       const widthPercent = (model.sizeMB / maxModelSize) * 100;
@@ -285,30 +159,31 @@ function ModelComparisonChart({ models }: { models: ModelComparison[] }) {
   }, [models]);
 
   return (
-    <div className="bg-[#0B0E14] p-6 md:p-8 rounded-lg border border-white/5">
+    <div className="rounded-lg border border-white/5 bg-[#0B0E14] p-6 md:p-8">
       <div className="space-y-4">
         {modelData.map((model, idx) => (
           <div key={idx}>
-            <div className="flex justify-between text-sm mb-2">
-              <span className="text-gray-400">
-                {model.label}
-              </span>
+            <div className="mb-2 flex justify-between text-sm">
+              <span className="text-gray-400">{model.label}</span>
               <span className={`${model.colors.text} font-mono`}>
                 {model.sizeMB.toFixed(1)} MB
               </span>
             </div>
-            <div className="h-2 bg-white/5 rounded-full overflow-hidden">
+            <div className="h-2 overflow-hidden rounded-full bg-white/5">
               <div
                 className={`h-full ${model.colors.bg} transition-all`}
-                style={{ width: `${model.widthPercent}%`, minWidth: model.widthPercent < 1 ? '2px' : '0' }}
+                style={{
+                  width: `${model.widthPercent}%`,
+                  minWidth: model.widthPercent < 1 ? "2px" : "0",
+                }}
               />
             </div>
           </div>
         ))}
       </div>
-      <div className="mt-8 pt-6 border-t border-white/10">
-        <div className="flex items-center gap-2 text-emerald-300/90 text-sm">
-          <Zap className="w-4 h-4" />
+      <div className="mt-8 border-t border-white/10 pt-6">
+        <div className="flex items-center gap-2 text-sm text-emerald-300/90">
+          <Zap className="h-4 w-4" />
           <span>Latency reduced to &lt;0.1s cold load</span>
         </div>
       </div>
@@ -334,8 +209,7 @@ export function StormSignal() {
   };
 
   return (
-    <main className="bg-[#0B0E14] min-h-screen font-sans selection:bg-blue-500/30">
-      {/* Hero Section */}
+    <main className="project-theme min-h-screen bg-[#0B0E14] font-sans selection:bg-blue-500/30">
       <CaseStudyHero
         title="Storm Signal"
         framing={
@@ -372,116 +246,152 @@ export function StormSignal() {
         }
       />
 
-      {/* Metrics Grid */}
       <section className="border-b border-white/5 bg-[#0B0E14]">
-        <div className="max-w-6xl mx-auto px-6 lg:px-8 pt-8 pb-12">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <StatCard label="Model Size" value="4.5 MB" subtext="Designed for local deployment" />
-            <StatCard label="Inference Latency" value="< 100ms" subtext="Real-time classification under load" />
-            <StatCard label="Weighted F1" value="92.8%" subtext="Across 36 categories (multi-label)" />
+        <div className="mx-auto max-w-6xl px-6 pb-12 pt-8 lg:px-8">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+            <CaseStudyStatCard
+              label="Model Size"
+              value="4.5 MB"
+              subtext="Designed for local deployment"
+            />
+            <CaseStudyStatCard
+              label="Inference Latency"
+              value="< 100ms"
+              subtext="Real-time classification under load"
+            />
+            <CaseStudyStatCard
+              label="Weighted F1"
+              value="92.8%"
+              subtext="Across 36 categories (multi-label)"
+            />
           </div>
         </div>
       </section>
 
-      {/* Context / Problem */}
-      <section className="py-12 md:py-20 bg-[#0B0E14]">
-        <div className="max-w-6xl mx-auto px-6 lg:px-8">
-          <SectionHeading 
-            title="The Context" 
+      <section className="bg-[#0B0E14] py-12 md:py-20">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <CaseStudySectionHeading
+            title="The Context"
             subtitle="Disasters generate high-volume, unstructured communication streams. Posts and direct reports arrive faster than human operators can triage them."
           />
           <div className="prose prose-invert max-w-none text-gray-400">
             <p className="text-base md:text-lg">
-              The risk is not isolated misclassification. It is signal overload. When routing systems are slow, inconsistent, or logically incoherent, critical requests for medical aid, shelter, or rescue are delayed, buried, or misprioritized.
+              The risk is not isolated misclassification. It is signal overload.
+              When routing systems are slow, inconsistent, or logically
+              incoherent, critical requests for medical aid, shelter, or rescue
+              are delayed, buried, or misprioritized.
             </p>
-            <p className="text-base md:text-lg mt-6">
-              Storm Signal is a high-fidelity prototype of a monitoring dashboard built to manage that flow under real-world constraints: offline availability, low compute overhead, and auditability.
+            <p className="mt-6 text-base md:text-lg">
+              Storm Signal is a high-fidelity prototype of a monitoring dashboard
+              built to manage that flow under real-world constraints: offline
+              availability, low compute overhead, and auditability.
             </p>
           </div>
         </div>
       </section>
 
-      {/* Design Doctrine */}
-      <section className="py-12 md:py-20 border-y border-white/5 bg-[#11141a]">
-        <div className="max-w-6xl mx-auto px-6 lg:px-8">
-           <SectionHeading title="Design Doctrine" />
-           <p className="text-gray-400 text-base leading-relaxed max-w-3xl mb-8 md:mb-12">
-           Disaster response punishes ambiguity: bandwidth is limited, conditions change fast, and operators need consistent routing under surge. This architecture favors compact, inspectable ML over API-dependent generative systems so behavior stays predictable when the environment isn't.
-           </p>
-           <div className="grid md:grid-cols-3 gap-4 md:gap-6">
-              {designDoctrineCards.map((card, idx) => (
-                <div key={idx} className="bg-[#151921] p-4 md:p-6 rounded-sm border border-white/5">
-                  <div className={`w-10 h-10 ${card.iconBgColor} rounded-sm flex items-center justify-center mb-4 ${card.iconColor}`}>
-                    {card.icon}
-                  </div>
-                  <h3 className="text-white font-bold mb-2">{card.title}</h3>
-                  <p className="text-gray-400 text-sm leading-relaxed">
-                    {card.description}
-                  </p>
+      <section className="border-y border-white/5 bg-[#11141a] py-12 md:py-20">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <CaseStudySectionHeading title="Design Doctrine" />
+          <p className="mb-8 max-w-3xl text-base leading-relaxed text-gray-400 md:mb-12">
+            Disaster response punishes ambiguity: bandwidth is limited,
+            conditions change fast, and operators need consistent routing under
+            surge. This architecture favors compact, inspectable ML over
+            API-dependent generative systems so behavior stays predictable when
+            the environment isn&apos;t.
+          </p>
+          <div className="grid gap-4 md:grid-cols-3 md:gap-6">
+            {designDoctrineCards.map((card, idx) => (
+              <div
+                key={idx}
+                className="rounded-sm border border-white/5 bg-[#151921] p-4 md:p-6"
+              >
+                <div
+                  className={`mb-4 flex h-10 w-10 items-center justify-center rounded-sm ${card.iconBgColor} ${card.iconColor}`}
+                >
+                  {card.icon}
                 </div>
-              ))}
+                <h3 className="mb-2 font-bold text-white">{card.title}</h3>
+                <p className="text-sm leading-relaxed text-gray-400">
+                  {card.description}
+                </p>
+              </div>
+            ))}
           </div>
         </div>
       </section>
 
-      {/* Architecture */}
-      <section className="py-10 md:py-12 bg-[#0B0E14]">
-        <div className="max-w-6xl mx-auto px-6 lg:px-8">
-           <SectionHeading 
-             title="System Architecture" 
-             subtitle="A monitoring dashboard with a constrained ML core. Messages are ingested, classified with confidence, surfaced for triage, and routed to human responders." 
-           />
-           
-           <div className="mt-8 md:mt-6">
-              {/* Diagram Surface */}
-              <div className="relative bg-[#151921] border border-white/10 rounded-lg p-3 md:p-3 lg:p-6">
-                 {/* Grid Background Pattern */}
-                 <div className="absolute inset-0 opacity-5 rounded-lg" style={{
-                   backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
-                   backgroundSize: '24px 24px'
-                 }} />
-                 
-                 <ArchitectureDesktopTablet />
-                 <ArchitectureMobile />
-              </div>
-           </div>
+      <section className="bg-[#0B0E14] py-10 md:py-12">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
+          <CaseStudySectionHeading
+            title="System Architecture"
+            subtitle="A monitoring dashboard with a constrained ML core. Messages are ingested, classified with confidence, surfaced for triage, and routed to human responders."
+          />
+
+          <div className="mt-8 md:mt-6">
+            <div className="relative rounded-lg border border-white/10 bg-[#151921] p-3 md:p-3 lg:p-6">
+              <div
+                className="absolute inset-0 rounded-lg opacity-5"
+                style={{
+                  backgroundImage:
+                    "radial-gradient(circle, currentColor 1px, transparent 1px)",
+                  backgroundSize: "24px 24px",
+                }}
+              />
+              <CaseStudyFlowDiagram
+                lanes={architectureLanes}
+                transitions={architectureTransitions}
+                accentTextClassName="text-blue-400"
+                accentBorderClassName="border-blue-400/25"
+                fallbackFinalOutputLabel="Responder Dispatch"
+              />
+            </div>
+          </div>
         </div>
       </section>
 
-      {/* Case Study: The Pivot */}
-      <section className="py-12 md:py-20 bg-[#151921] border-y border-white/5">
-        <div className="max-w-5xl mx-auto px-6 lg:px-8">
-           <div className="grid md:grid-cols-2 gap-8 md:gap-12 items-center">
-              <div>
-                <h3 className="text-sm font-mono text-blue-400 uppercase tracking-widest mb-2">Key Engineering Trade-off</h3>
-                <h2 className="text-2xl md:text-3xl font-bold text-white mb-4 md:mb-6">Novelty vs. Utility</h2>
-                <div className="space-y-4 md:space-y-6 text-gray-400 leading-relaxed">
-                  <p>
-                    Early iterations used a Random Forest model. Artifact size approached ~900 MB and proved unsuitable for lightweight or edge deployment.
-                  </p>
-                  <p>
-                    This was replaced with Logistic Regression to make edge deployment viable. The artifact dropped from 67.7 MB to 13.0 MB with vocabulary filtering, and to 4.5 MB with a 15K feature cap without sacrificing operational performance.
-                  </p>
-                  <p>
-                    The final stack prioritizes determinism, inspectability, and predictable inference behavior over model novelty.
-                  </p>
-                </div>
+      <section className="border-y border-white/5 bg-[#151921] py-12 md:py-20">
+        <div className="mx-auto max-w-5xl px-6 lg:px-8">
+          <div className="grid items-center gap-8 md:grid-cols-2 md:gap-12">
+            <div>
+              <h3 className="mb-2 font-mono text-sm uppercase tracking-widest text-blue-400">
+                Key Engineering Trade-off
+              </h3>
+              <h2 className="mb-4 text-2xl font-bold text-white md:mb-6 md:text-3xl">
+                Novelty vs. Utility
+              </h2>
+              <div className="space-y-4 leading-relaxed text-gray-400 md:space-y-6">
+                <p>
+                  Early iterations used a Random Forest model. Artifact size
+                  approached ~900 MB and proved unsuitable for lightweight or
+                  edge deployment.
+                </p>
+                <p>
+                  This was replaced with Logistic Regression to make edge
+                  deployment viable. The artifact dropped from 67.7 MB to 13.0
+                  MB with vocabulary filtering, and to 4.5 MB with a 15K feature
+                  cap without sacrificing operational performance.
+                </p>
+                <p>
+                  The final stack prioritizes determinism, inspectability, and
+                  predictable inference behavior over model novelty.
+                </p>
               </div>
-              
-              <ModelComparisonChart models={modelComparisons} />
-           </div>
+            </div>
+
+            <ModelComparisonChart models={modelComparisons} />
+          </div>
         </div>
       </section>
 
-      {/* Navigation */}
-      <section className="py-12 bg-[#0B0E14] border-t border-white/5">
-        <div className="max-w-6xl mx-auto px-6 lg:px-8">
+      <section className="border-t border-white/5 bg-[#0B0E14] py-12">
+        <div className="mx-auto max-w-6xl px-6 lg:px-8">
           <a
             href="/#page-top"
             onClick={handleBackToCaseStudies}
-            className="inline-flex items-center gap-2 text-gray-500 hover:text-white transition-colors text-sm font-medium"
+            className="inline-flex items-center gap-2 text-sm font-medium text-gray-500 transition-colors hover:text-white"
           >
-            <ArrowLeft className="w-4 h-4" />
+            <ArrowLeft className="h-4 w-4" />
             Back to Case Studies
           </a>
         </div>
@@ -489,4 +399,3 @@ export function StormSignal() {
     </main>
   );
 }
-

--- a/src/app/projects/StormSignal.tsx
+++ b/src/app/projects/StormSignal.tsx
@@ -232,7 +232,7 @@ export function StormSignal() {
         }
       />
 
-      <section className="border-b border-white/5 bg-[#0B0E14]">
+      <section className="border-b border-white/5 bg-[var(--project-page-bg)]">
         <div className="mx-auto max-w-6xl px-6 pb-12 pt-8 lg:px-8">
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
             <CaseStudyStatCard
@@ -254,7 +254,7 @@ export function StormSignal() {
         </div>
       </section>
 
-      <section className="bg-[#0B0E14] py-12 md:py-20">
+      <section className="bg-[var(--project-page-bg)] py-12 md:py-20">
         <div className="mx-auto max-w-6xl px-6 lg:px-8">
           <CaseStudySectionHeading
             title="The Context"
@@ -307,7 +307,7 @@ export function StormSignal() {
         </div>
       </section>
 
-      <section className="bg-[#0B0E14] py-10 md:py-12">
+      <section className="bg-[var(--project-page-bg)] py-10 md:py-12">
         <div className="mx-auto max-w-6xl px-6 lg:px-8">
           <CaseStudySectionHeading
             title="System Architecture"
@@ -370,7 +370,7 @@ export function StormSignal() {
         </div>
       </section>
 
-      <section className="border-t border-white/5 bg-[#0B0E14] py-12">
+      <section className="border-t border-white/5 bg-[var(--project-page-bg)] py-12">
         <div className="mx-auto max-w-6xl px-6 lg:px-8">
           <a
             href="/#page-top"

--- a/src/app/projects/WalkabilityIndex.tsx
+++ b/src/app/projects/WalkabilityIndex.tsx
@@ -14,7 +14,7 @@ const ctas = [
     variant: "primary" as const,
   },
   {
-    label: "View on GitHub",
+    label: "View on Github",
     href: "https://github.com/ghgeist/urbanism_project",
     icon: <Github className="h-4 w-4" />,
     variant: "secondary" as const,
@@ -291,4 +291,3 @@ export function WalkabilityIndexDetail() {
     </ProjectPageShell>
   );
 }
-

--- a/src/app/projects/WalkabilityIndex.tsx
+++ b/src/app/projects/WalkabilityIndex.tsx
@@ -64,7 +64,7 @@ export function WalkabilityIndexDetail() {
           </>
         }
         media={
-          <div className="relative h-56 w-full md:h-80">
+          <div className="relative aspect-video w-full">
             <ImageWithFallback
               src="https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?auto=format&fit=crop&q=80&w=1600"
               alt="Walkability map view"

--- a/src/app/projects/components/CaseStudyCtaButton.tsx
+++ b/src/app/projects/components/CaseStudyCtaButton.tsx
@@ -16,9 +16,9 @@ export type CaseStudyCtaButtonProps = {
 
 const CTA_VARIANT_STYLES: Record<CaseStudyCtaVariant, string> = {
   primary:
-    "border border-[color:var(--project-accent-border)] bg-[var(--project-accent-strong)] text-[var(--project-accent-on)] hover:border-[color:var(--project-accent)] hover:bg-[var(--project-accent)]",
+    "border border-[color:var(--project-accent-border)] bg-[var(--project-accent-strong)] text-[var(--project-accent-on)] shadow-lg shadow-[color:var(--project-accent-soft)] hover:border-[color:var(--project-accent)] hover:bg-[var(--project-accent)]",
   secondary:
-    "border border-[color:var(--surface-border-default)] bg-[var(--surface-content-bg)] text-[var(--project-body-text)] hover:border-[color:var(--surface-border-emphasis)] hover:bg-[var(--surface-highlight-bg)]",
+    "border border-white/10 bg-white/5 text-[var(--project-body-text)] hover:border-white/20 hover:bg-white/10",
 };
 
 export function CaseStudyCtaButton({
@@ -36,7 +36,7 @@ export function CaseStudyCtaButton({
       target={target}
       rel={target === "_blank" ? "noreferrer" : undefined}
       className={cn(
-        "inline-flex h-10 items-center justify-center gap-2.5 rounded-md px-5 text-sm font-medium leading-none transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30",
+        "inline-flex items-center justify-center gap-2 rounded-sm px-5 py-2.5 text-sm font-medium leading-none transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30",
         CTA_VARIANT_STYLES[variant],
         className
       )}

--- a/src/app/projects/components/CaseStudyFlowDiagram.tsx
+++ b/src/app/projects/components/CaseStudyFlowDiagram.tsx
@@ -1,0 +1,233 @@
+import { Fragment } from "react";
+import type { ReactNode } from "react";
+import { motion as Motion, useReducedMotion } from "motion/react";
+import { cn } from "@/app/components/ui/utils";
+
+export type CaseStudyFlowLane = {
+  title: string;
+  icon: ReactNode;
+  iconColorClassName: string;
+  nodes: string[];
+  tightSpacing?: boolean;
+};
+
+type CaseStudyFlowDiagramProps = {
+  lanes: CaseStudyFlowLane[];
+  transitions: string[];
+  accentTextClassName: string;
+  accentBorderClassName: string;
+  fallbackFinalOutputLabel: string;
+  className?: string;
+  gridClassName?: string;
+  laneClassName?: string;
+};
+
+function FlowNode({ text }: { text: string }) {
+  return (
+    <div className="w-full rounded-md border border-white/10 bg-white/[0.03] px-3 py-2 text-center">
+      <p className="text-[13px] leading-snug text-gray-300">{text}</p>
+    </div>
+  );
+}
+
+function FlowLane({
+  lane,
+  index,
+  nextLabel,
+  isFinalLane,
+  accentTextClassName,
+  accentBorderClassName,
+  fallbackFinalOutputLabel,
+  laneClassName,
+}: {
+  lane: CaseStudyFlowLane;
+  index: number;
+  nextLabel?: string;
+  isFinalLane: boolean;
+  accentTextClassName: string;
+  accentBorderClassName: string;
+  fallbackFinalOutputLabel: string;
+  laneClassName?: string;
+}) {
+  const laneNumber = String(index + 1).padStart(2, "0");
+  const outputLabel = nextLabel ?? (isFinalLane ? fallbackFinalOutputLabel : "");
+
+  return (
+    <div
+      className={cn(
+        "flex h-full min-h-0 flex-col rounded-lg border border-white/10 bg-white/[0.02] p-3.5 sm:min-h-[180px] md:min-h-[170px] md:p-3",
+        laneClassName,
+      )}
+    >
+      <div className="mb-3 flex items-start justify-between gap-2 md:mb-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <div className={cn("flex-shrink-0", lane.iconColorClassName)}>{lane.icon}</div>
+          <h3 className="text-xs font-semibold text-white md:text-sm">{lane.title}</h3>
+        </div>
+        <span
+          className={cn(
+            "rounded border px-1.5 py-0.5 font-mono text-[11px]",
+            accentTextClassName,
+            accentBorderClassName,
+          )}
+        >
+          {laneNumber}
+        </span>
+      </div>
+
+      <div className="flex flex-1 flex-col justify-start">
+        <div
+          className={cn(
+            "mx-auto w-full max-w-full md:max-w-[240px]",
+            lane.tightSpacing ? "space-y-1" : "space-y-2",
+          )}
+        >
+          {lane.nodes.map((node, nodeIndex) => (
+            <FlowNode key={nodeIndex} text={node} />
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-2 hidden border-t border-white/10 pt-2 sm:block md:mt-1.5 md:pt-1.5">
+        <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-0.5 text-center text-[11px]">
+          <span className={cn("font-mono uppercase tracking-wide", accentTextClassName)}>Output:</span>
+          <span className={accentTextClassName}>{outputLabel}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AnimatedFlowLane({
+  lane,
+  idx,
+  nextLabel,
+  accentTextClassName,
+  accentBorderClassName,
+  fallbackFinalOutputLabel,
+  laneClassName,
+  isFinalLane,
+  shouldReduceMotion,
+}: {
+  lane: CaseStudyFlowLane;
+  idx: number;
+  nextLabel?: string;
+  accentTextClassName: string;
+  accentBorderClassName: string;
+  fallbackFinalOutputLabel: string;
+  laneClassName?: string;
+  isFinalLane: boolean;
+  shouldReduceMotion: boolean;
+}) {
+  const laneContent = (
+    <FlowLane
+      lane={lane}
+      index={idx}
+      nextLabel={nextLabel}
+      isFinalLane={isFinalLane}
+      accentTextClassName={accentTextClassName}
+      accentBorderClassName={accentBorderClassName}
+      fallbackFinalOutputLabel={fallbackFinalOutputLabel}
+      laneClassName={laneClassName}
+    />
+  );
+
+  if (shouldReduceMotion) {
+    return <div className="h-full">{laneContent}</div>;
+  }
+
+  return (
+    <Motion.div
+      initial={{ opacity: 0, y: 10 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{ duration: 0.35, delay: idx * 0.08 }}
+      className="h-full"
+    >
+      {laneContent}
+    </Motion.div>
+  );
+}
+
+function MobileFlowConnector({
+  label,
+  accentTextClassName,
+}: {
+  label: string;
+  accentTextClassName: string;
+}) {
+  return (
+    <div className="flex items-center justify-center gap-2 py-1 text-center text-[11px]">
+      <span className={cn("font-mono uppercase tracking-wide", accentTextClassName)}>Output:</span>
+      <span className={accentTextClassName}>{label}</span>
+    </div>
+  );
+}
+
+export function CaseStudyFlowDiagram({
+  lanes,
+  transitions,
+  accentTextClassName,
+  accentBorderClassName,
+  fallbackFinalOutputLabel,
+  className,
+  gridClassName,
+  laneClassName,
+}: CaseStudyFlowDiagramProps) {
+  const reducedMotion = useReducedMotion();
+  const shouldReduceMotion = Boolean(reducedMotion);
+
+  return (
+    <div className={cn("relative", className)}>
+      <div className="relative hidden sm:block">
+        <div
+          className={cn(
+            "relative grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-3 lg:grid-cols-4",
+            gridClassName,
+          )}
+        >
+          {lanes.map((lane, idx) => (
+            <AnimatedFlowLane
+              key={idx}
+              lane={lane}
+              idx={idx}
+              nextLabel={transitions[idx]}
+              accentTextClassName={accentTextClassName}
+              accentBorderClassName={accentBorderClassName}
+              fallbackFinalOutputLabel={fallbackFinalOutputLabel}
+              laneClassName={laneClassName}
+              isFinalLane={idx === lanes.length - 1}
+              shouldReduceMotion={shouldReduceMotion}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="relative sm:hidden">
+        <div className="space-y-2">
+          {lanes.map((lane, idx) => (
+            <Fragment key={idx}>
+              <AnimatedFlowLane
+                lane={lane}
+                idx={idx}
+                nextLabel={transitions[idx]}
+                accentTextClassName={accentTextClassName}
+                accentBorderClassName={accentBorderClassName}
+                fallbackFinalOutputLabel={fallbackFinalOutputLabel}
+                laneClassName={laneClassName}
+                isFinalLane={idx === lanes.length - 1}
+                shouldReduceMotion={shouldReduceMotion}
+              />
+              {idx < transitions.length ? (
+                <MobileFlowConnector
+                  label={transitions[idx]}
+                  accentTextClassName={accentTextClassName}
+                />
+              ) : null}
+            </Fragment>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/projects/components/CaseStudyHero.tsx
+++ b/src/app/projects/components/CaseStudyHero.tsx
@@ -87,8 +87,8 @@ export function CaseStudyHero({
             </Link>
           </div>
 
-          <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
-            <div>
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)] lg:items-center xl:gap-10">
+            <div className="lg:pr-4">
               <h1
                 className={cn(
                   "text-4xl font-bold tracking-tight text-white md:text-6xl",
@@ -100,7 +100,7 @@ export function CaseStudyHero({
 
               <div
                 className={cn(
-                  "mt-6 max-w-3xl text-base leading-relaxed text-[var(--project-body-text)] md:text-lg",
+                  "mt-6 max-w-2xl text-base leading-relaxed text-[var(--project-body-text)] md:text-lg",
                   framingClassName
                 )}
               >
@@ -108,7 +108,7 @@ export function CaseStudyHero({
               </div>
 
               {ctas ? (
-                <div className={cn("mt-8 flex flex-wrap items-center gap-4", ctasClassName)}>
+                <div className={cn("mt-8 flex min-h-11 flex-wrap items-center gap-3 sm:gap-4", ctasClassName)}>
                   {ctas}
                 </div>
               ) : null}

--- a/src/app/projects/components/CaseStudyHero.tsx
+++ b/src/app/projects/components/CaseStudyHero.tsx
@@ -72,61 +72,56 @@ export function CaseStudyHero({
           initial={{ opacity: 0.95, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4 }}
-          className={cn("max-w-5xl", contentClassName)}
+          className={cn("max-w-6xl", contentClassName)}
         >
-          <div
-            className={cn(
-              "mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between",
-              topRowClassName
-            )}
-          >
+          <div className={cn("mb-8", topRowClassName)}>
             <Link
               to={backTo}
               className={cn(
-                "inline-flex items-center gap-2 font-mono text-xs uppercase tracking-[0.12em] text-[var(--project-meta-text)] transition-colors hover:text-[var(--project-body-text)]",
+                "inline-flex items-center gap-2 text-sm font-medium text-[var(--project-meta-text)] transition-colors hover:text-white",
                 backLinkClassName
               )}
             >
-              <ArrowLeft className="h-3 w-3" />
+              <ArrowLeft className="h-4 w-4" />
               {backLabel}
             </Link>
-            {ctas ? (
-              <div
+          </div>
+
+          <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
+            <div>
+              <h1
                 className={cn(
-                  "flex flex-wrap items-center gap-3",
-                  ctasClassName
+                  "text-4xl font-bold tracking-tight text-white md:text-6xl",
+                  titleClassName
                 )}
               >
-                {ctas}
+                {title}
+              </h1>
+
+              <div
+                className={cn(
+                  "mt-6 max-w-3xl text-base leading-relaxed text-[var(--project-body-text)] md:text-lg",
+                  framingClassName
+                )}
+              >
+                {framing}
               </div>
-            ) : null}
-          </div>
 
-          <h1
-            className={cn(
-              "text-4xl font-bold tracking-tight text-white md:text-6xl",
-              titleClassName
-            )}
-          >
-            {title}
-          </h1>
+              {ctas ? (
+                <div className={cn("mt-8 flex flex-wrap items-center gap-4", ctasClassName)}>
+                  {ctas}
+                </div>
+              ) : null}
+            </div>
 
-          <div
-            className={cn(
-              "mt-4 max-w-3xl text-base leading-relaxed text-[var(--project-body-text)] md:text-lg",
-              framingClassName
-            )}
-          >
-            {framing}
-          </div>
-
-          <div
-            className={cn(
-              "mt-8 overflow-hidden rounded-md border border-[color:var(--surface-border-default)] bg-[var(--surface-meta-bg)]",
-              mediaClassName
-            )}
-          >
-            {media}
+            <div
+              className={cn(
+                "mt-2 overflow-hidden rounded-md border border-[color:var(--surface-border-default)] bg-[var(--surface-meta-bg)] lg:mt-0",
+                mediaClassName
+              )}
+            >
+              {media}
+            </div>
           </div>
         </Motion.div>
       </div>

--- a/src/app/projects/components/CaseStudySectionHeading.tsx
+++ b/src/app/projects/components/CaseStudySectionHeading.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/app/components/ui/utils";
+
+type CaseStudySectionHeadingProps = {
+  title: string;
+  subtitle?: string;
+  className?: string;
+  titleClassName?: string;
+  subtitleClassName?: string;
+};
+
+export function CaseStudySectionHeading({
+  title,
+  subtitle,
+  className,
+  titleClassName,
+  subtitleClassName,
+}: CaseStudySectionHeadingProps) {
+  return (
+    <div className={cn("mb-6 md:mb-8", className)}>
+      <h2 className={cn("text-2xl font-bold tracking-tight text-white md:text-3xl", titleClassName)}>
+        {title}
+      </h2>
+      {subtitle ? (
+        <p className={cn("mt-3 max-w-2xl text-base leading-relaxed text-gray-400 md:text-lg", subtitleClassName)}>
+          {subtitle}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/projects/components/CaseStudyStatCard.tsx
+++ b/src/app/projects/components/CaseStudyStatCard.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/app/components/ui/utils";
+
+type CaseStudyStatCardProps = {
+  label: string;
+  value: string;
+  subtext: string;
+  className?: string;
+  labelClassName?: string;
+  valueClassName?: string;
+  subtextClassName?: string;
+};
+
+export function CaseStudyStatCard({
+  label,
+  value,
+  subtext,
+  className,
+  labelClassName,
+  valueClassName,
+  subtextClassName,
+}: CaseStudyStatCardProps) {
+  return (
+    <div className={cn("rounded-sm border border-white/5 bg-[#151921] p-4 md:p-5", className)}>
+      <div className={cn("mb-1 font-mono text-xs uppercase tracking-wider text-gray-500", labelClassName)}>
+        {label}
+      </div>
+      <div className={cn("mb-1 text-xl font-bold text-white md:text-2xl", valueClassName)}>
+        {value}
+      </div>
+      <div className={cn("text-sm text-gray-400", subtextClassName)}>{subtext}</div>
+    </div>
+  );
+}

--- a/src/app/projects/hooks/useBackToCaseStudies.ts
+++ b/src/app/projects/hooks/useBackToCaseStudies.ts
@@ -1,0 +1,37 @@
+import { useCallback } from "react";
+import type { MouseEvent } from "react";
+import { useNavigate } from "react-router-dom";
+
+type UseBackToCaseStudiesOptions = {
+  topAnchorSelector?: string;
+  offsetPx?: number;
+  delayMs?: number;
+};
+
+export function useBackToCaseStudies(
+  options: UseBackToCaseStudiesOptions = {},
+) {
+  const {
+    topAnchorSelector = "#page-top",
+    offsetPx = 96,
+    delayMs = 100,
+  } = options;
+  const navigate = useNavigate();
+
+  return useCallback(
+    (e: MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault();
+      navigate("/");
+      setTimeout(() => {
+        const element = document.querySelector(topAnchorSelector);
+        if (element) {
+          const y = element.getBoundingClientRect().top + window.scrollY - offsetPx;
+          window.scrollTo({ top: y, behavior: "smooth" });
+        } else {
+          window.scrollTo({ top: 0, behavior: "smooth" });
+        }
+      }, delayMs);
+    },
+    [navigate, topAnchorSelector, offsetPx, delayMs],
+  );
+}

--- a/src/test/project-pages.test.tsx
+++ b/src/test/project-pages.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * Project Page Integration Tests
+ *
+ * Test Philosophy: Catch "long tail" issues that automated tools flag
+ * - ✅ Test: Accessibility (semantic HTML structure, heading hierarchy)
+ * - ✅ Test: Link validation (external links have proper attributes, security)
+ * - ✅ Test: Navigation/routing (back links work correctly)
+ * - ✅ Test: CTA buttons (proper href, target, rel attributes)
+ * - ✅ Test: Image loading (alt text present for accessibility)
+ * - ✅ Test: Component composition (pages render without errors, consistent structure)
+ *
+ * These tests catch issues that TypeScript, ESLint, and automated tools flag
+ * but aren't caught by basic rendering tests. Focus on functionality over appearance.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { Bantr } from "@/app/projects/Bantr";
+import { ReplacementTrap } from "@/app/projects/ReplacementTrap";
+import { WalkabilityIndexDetail } from "@/app/projects/WalkabilityIndex";
+import { StormSignal } from "@/app/projects/StormSignal";
+
+describe("Project Pages - Accessibility", () => {
+  it("Bantr page has semantic HTML structure", () => {
+    render(
+      <MemoryRouter>
+        <Bantr />
+      </MemoryRouter>
+    );
+
+    // Check for main landmark
+    const main = document.querySelector("main");
+    expect(main).toBeTruthy();
+
+    // Check for headings hierarchy
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toBeTruthy();
+    expect(h1.textContent).toContain("Bantr");
+  });
+
+  it("ReplacementTrap page has semantic HTML structure", () => {
+    render(
+      <MemoryRouter>
+        <ReplacementTrap />
+      </MemoryRouter>
+    );
+
+    const main = document.querySelector("main");
+    expect(main).toBeTruthy();
+
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toBeTruthy();
+    expect(h1.textContent).toContain("Replacement Trap");
+  });
+
+  it("WalkabilityIndex page has semantic HTML structure", () => {
+    render(
+      <MemoryRouter>
+        <WalkabilityIndexDetail />
+      </MemoryRouter>
+    );
+
+    const main = document.querySelector("main");
+    expect(main).toBeTruthy();
+
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toBeTruthy();
+    expect(h1.textContent).toContain("Walkability Index");
+  });
+
+  it("StormSignal page has semantic HTML structure", () => {
+    render(
+      <MemoryRouter>
+        <StormSignal />
+      </MemoryRouter>
+    );
+
+    const main = document.querySelector("main");
+    expect(main).toBeTruthy();
+
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toBeTruthy();
+    expect(h1.textContent).toContain("Storm Signal");
+  });
+});
+
+describe("Project Pages - Link Validation", () => {
+  const pages = [
+    { Component: Bantr, name: "Bantr" },
+    { Component: ReplacementTrap, name: "ReplacementTrap" },
+    { Component: WalkabilityIndexDetail, name: "WalkabilityIndex" },
+    { Component: StormSignal, name: "StormSignal" },
+  ];
+
+  pages.forEach(({ Component, name }) => {
+    it(`${name} external links have proper attributes`, () => {
+      render(
+        <MemoryRouter>
+          <Component />
+        </MemoryRouter>
+      );
+
+      const externalLinks = screen.getAllByRole("link").filter(
+        (link) => link.getAttribute("href")?.startsWith("http")
+      );
+
+      // If there are external links, validate them
+      if (externalLinks.length > 0) {
+        externalLinks.forEach((link) => {
+          const href = link.getAttribute("href");
+          const target = link.getAttribute("target");
+          const rel = link.getAttribute("rel");
+
+          expect(href).toBeTruthy();
+          if (target === "_blank") {
+            expect(rel).toContain("noreferrer");
+          }
+        });
+      }
+    });
+  });
+});
+
+describe("Project Pages - Navigation", () => {
+  it("Bantr back link navigates correctly", () => {
+    render(
+      <MemoryRouter>
+        <Bantr />
+      </MemoryRouter>
+    );
+
+    const backLinks = screen.getAllByText("Back to Case Studies");
+    expect(backLinks.length).toBeGreaterThan(0);
+    const heroBackLink = backLinks[0];
+    expect(heroBackLink).toBeTruthy();
+    expect(heroBackLink.closest("a")).toHaveAttribute("href", "/");
+  });
+
+  it("ReplacementTrap back link navigates correctly", () => {
+    render(
+      <MemoryRouter>
+        <ReplacementTrap />
+      </MemoryRouter>
+    );
+
+    // ReplacementTrap has multiple back links - check the first one (in hero)
+    const backLinks = screen.getAllByText("Back to Case Studies");
+    expect(backLinks.length).toBeGreaterThan(0);
+    const heroBackLink = backLinks[0];
+    expect(heroBackLink).toBeTruthy();
+    expect(heroBackLink.closest("a")).toHaveAttribute("href", "/");
+  });
+
+  it("WalkabilityIndex back link navigates correctly", () => {
+    render(
+      <MemoryRouter>
+        <WalkabilityIndexDetail />
+      </MemoryRouter>
+    );
+
+    const backLinks = screen.getAllByText("Back to Case Studies");
+    expect(backLinks.length).toBeGreaterThan(0);
+    const heroBackLink = backLinks[0];
+    expect(heroBackLink).toBeTruthy();
+    expect(heroBackLink.closest("a")).toHaveAttribute("href", "/");
+  });
+
+  it("StormSignal back link navigates correctly", () => {
+    render(
+      <MemoryRouter>
+        <StormSignal />
+      </MemoryRouter>
+    );
+
+    const backLinks = screen.getAllByText("Back to Case Studies");
+    expect(backLinks.length).toBeGreaterThan(0);
+    const heroBackLink = backLinks[0];
+    expect(heroBackLink).toBeTruthy();
+    expect(heroBackLink.closest("a")).toHaveAttribute("href", "/");
+  });
+});
+
+describe("Project Pages - CTA Buttons", () => {
+  it("Bantr CTA buttons have required attributes", () => {
+    render(
+      <MemoryRouter>
+        <Bantr />
+      </MemoryRouter>
+    );
+
+    const ctaButtons = screen.getAllByRole("link").filter((link) =>
+      ["Live Demo", "View on Github"].some((text) =>
+        link.textContent?.includes(text)
+      )
+    );
+
+    ctaButtons.forEach((button) => {
+      expect(button).toHaveAttribute("href");
+      const href = button.getAttribute("href");
+      expect(href).toBeTruthy();
+      if (href?.startsWith("http")) {
+        const target = button.getAttribute("target");
+        if (target === "_blank") {
+          expect(button.getAttribute("rel")).toContain("noreferrer");
+        }
+      }
+    });
+  });
+
+  it("ReplacementTrap CTA buttons have required attributes", () => {
+    render(
+      <MemoryRouter>
+        <ReplacementTrap />
+      </MemoryRouter>
+    );
+
+    const ctaButtons = screen.getAllByRole("link").filter((link) =>
+      ["Read the Essay", "View on Github"].some((text) =>
+        link.textContent?.includes(text)
+      )
+    );
+
+    ctaButtons.forEach((button) => {
+      expect(button).toHaveAttribute("href");
+      const href = button.getAttribute("href");
+      expect(href).toBeTruthy();
+      if (href?.startsWith("http")) {
+        const target = button.getAttribute("target");
+        if (target === "_blank") {
+          expect(button.getAttribute("rel")).toContain("noreferrer");
+        }
+      }
+    });
+  });
+
+  it("WalkabilityIndex CTA buttons have required attributes", () => {
+    render(
+      <MemoryRouter>
+        <WalkabilityIndexDetail />
+      </MemoryRouter>
+    );
+
+    const ctaButtons = screen.getAllByRole("link").filter((link) =>
+      ["Live Demo", "View on Github"].some((text) =>
+        link.textContent?.includes(text)
+      )
+    );
+
+    ctaButtons.forEach((button) => {
+      expect(button).toHaveAttribute("href");
+      const href = button.getAttribute("href");
+      expect(href).toBeTruthy();
+      if (href?.startsWith("http")) {
+        const target = button.getAttribute("target");
+        if (target === "_blank") {
+          expect(button.getAttribute("rel")).toContain("noreferrer");
+        }
+      }
+    });
+  });
+
+  it("StormSignal CTA buttons have required attributes", () => {
+    render(
+      <MemoryRouter>
+        <StormSignal />
+      </MemoryRouter>
+    );
+
+    const ctaButtons = screen.getAllByRole("link").filter((link) =>
+      ["Live Demo", "View on Github"].some((text) =>
+        link.textContent?.includes(text)
+      )
+    );
+
+    ctaButtons.forEach((button) => {
+      expect(button).toHaveAttribute("href");
+      const href = button.getAttribute("href");
+      expect(href).toBeTruthy();
+      if (href?.startsWith("http")) {
+        const target = button.getAttribute("target");
+        if (target === "_blank") {
+          expect(button.getAttribute("rel")).toContain("noreferrer");
+        }
+      }
+    });
+  });
+});
+
+describe("Project Pages - Image Loading", () => {
+  const pages = [
+    { Component: Bantr, name: "Bantr" },
+    { Component: ReplacementTrap, name: "ReplacementTrap" },
+    { Component: WalkabilityIndexDetail, name: "WalkabilityIndex" },
+    { Component: StormSignal, name: "StormSignal" },
+  ];
+
+  pages.forEach(({ Component, name }) => {
+    it(`${name} images have alt text`, () => {
+      render(
+        <MemoryRouter>
+          <Component />
+        </MemoryRouter>
+      );
+
+      const images = document.querySelectorAll("img");
+      if (images.length > 0) {
+        images.forEach((img) => {
+          const alt = img.getAttribute("alt");
+          // Alt text should exist (even if empty for decorative images)
+          expect(alt).not.toBeNull();
+        });
+      }
+    });
+  });
+});
+
+describe("Project Pages - Component Composition", () => {
+  it("All project pages render without errors", () => {
+    const pages = [
+      { Component: Bantr, name: "Bantr" },
+      { Component: ReplacementTrap, name: "ReplacementTrap" },
+      { Component: WalkabilityIndexDetail, name: "WalkabilityIndex" },
+      { Component: StormSignal, name: "StormSignal" },
+    ];
+
+    pages.forEach(({ Component, name }) => {
+      expect(() => {
+        render(
+          <MemoryRouter>
+            <Component />
+          </MemoryRouter>
+        );
+      }).not.toThrow();
+    });
+  });
+
+  it("All project pages have consistent structure", () => {
+    const pages = [
+      { Component: Bantr, name: "Bantr" },
+      { Component: ReplacementTrap, name: "ReplacementTrap" },
+      { Component: WalkabilityIndexDetail, name: "WalkabilityIndex" },
+      { Component: StormSignal, name: "StormSignal" },
+    ];
+
+    pages.forEach(({ Component }) => {
+      const { container } = render(
+        <MemoryRouter>
+          <Component />
+        </MemoryRouter>
+      );
+
+      // All pages should have a main element or section
+      const main = container.querySelector("main");
+      const section = container.querySelector("section");
+      expect(main || section).toBeTruthy();
+
+      // All pages should have at least one heading
+      const heading = container.querySelector("h1");
+      expect(heading).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared UI primitives (`CaseStudyHero`, `CaseStudyCtaButton`) used across multiple pages and significantly refactors two project pages, so visual/layout regressions are plausible; changes are UI-only with added tests and no data/auth impact.
> 
> **Overview**
> Introduces shared case-study primitives (`CaseStudyFlowDiagram`, `CaseStudySectionHeading`, `CaseStudyStatCard`) plus a reusable `useBackToCaseStudies` hook, then refactors `StormSignal` and heavily restructures `ReplacementTrap` to use these components (including reduced-motion-safe reveals) and to align hero/layout/metrics/architecture modules.
> 
> Normalizes CTA styling via `CaseStudyCtaButton` updates, adjusts `CaseStudyHero` layout to a consistent two-column hero with revised back-link/CTA placement, and standardizes hero media to `aspect-video` in `Bantr` and `WalkabilityIndex` while also tweaking CTA labels (“GitHub” -> “Github”).
> 
> Adds `src/test/project-pages.test.tsx` integration coverage for semantic structure, link attributes, navigation, CTAs, images, and render sanity, and updates design-system docs/contracts with a new project page authoring checklist and clarified supported composition patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3a37553ed1631c183fd526570afeee30a589422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->