### PR TITLE
Wire prerender into CI and verify contract

### DIFF
--- a/.cursor/rules/iteration-workflow.mdc
+++ b/.cursor/rules/iteration-workflow.mdc
@@ -7,17 +7,21 @@ alwaysApply: false
 
 Commands and shell notes: see `CLAUDE.md` and `AGENTS.md`. Verification steps: `.verify.yml` (or `./script/verify`).
 
+Keep `.verify.yml`, `script/verify`, and `.github/workflows/deploy.yml` aligned when the pipeline changes.
+
 ## Quick vs thorough
 
 **Fast path** (content/UI tweaks): edit → `npm run dev` → visual check → `npm run build` before commit.
 
-**Thorough path** (routes, config, deps, app shell): plan → edit → `npx tsc --noEmit` → `npm run test:ci` → `npm run build` → visual check on affected routes.
+**Thorough path** (routes, config, deps, app shell, metadata): plan → edit → `npx tsc --noEmit` → `npm run test:ci` → `npm run build:static` → visual check on affected routes.
+
+`npm run build:static` = `npm run build` + `npm run prerender`. Prerender needs Playwright Chromium (`npx playwright install chromium`). Prefer plain `npm run build` for the fast inner loop; use `build:static` or `./script/verify` when you need no-JS HTML snapshots in `dist/`.
 
 ## When to run full verification
 
 - Before pushing to main or opening a PR
 - After changing dependencies, `tsconfig`, or Vite config
-- After changing routing or app shell
+- After changing routing, app shell, or the prerender script
 
 Light check (visual + build) is enough for copy-only, styling tweaks, or small UI prop changes.
 
@@ -25,6 +29,10 @@ Light check (visual + build) is enough for copy-only, styling tweaks, or small U
 
 - CSS: `npm run lint:css` · TS/JS: `npm run lint:js` (or `npm run lint`)
 - If the environment cannot run verify: note "Verify locally with: ./script/verify"
+
+## Routes and discoverability
+
+Adding a route requires updating the `siteRoutes` registry **and** `public/sitemap.xml` (and `public/llms.txt`). Prerender reads paths from `dist/sitemap.xml` — do not hardcode a second route list.
 
 ## SPA routing
 
@@ -34,4 +42,5 @@ If routing behavior changes, update **both** `public/404.html` and the redirect 
 
 - Build/type errors: fix reported files; re-run `npx tsc --noEmit` and `npm run build`
 - Test failures: check `src/test/`; fix assertions or component behavior
+- Prerender failures: check `script/prerender.js` assertions; ensure Chromium is installed
 - Keep `CLAUDE.md` / `AGENTS.md` in sync if stack or verification steps change

--- a/.cursor/rules/iteration-workflow.mdc
+++ b/.cursor/rules/iteration-workflow.mdc
@@ -5,9 +5,7 @@ alwaysApply: false
 
 # Iteration Workflow for Portfolio Site
 
-Commands and shell notes: see `CLAUDE.md` and `AGENTS.md`. Verification steps: `.verify.yml` (or `./script/verify`).
-
-Keep `.verify.yml`, `script/verify`, and `.github/workflows/deploy.yml` aligned when the pipeline changes.
+Commands and shell notes: see `CLAUDE.md` and `AGENTS.md`. Verification contract: `.verify.yml`. Implementation: `./script/verify` (CI: `bash script/verify --skip-install` after `npm ci`).
 
 ## Quick vs thorough
 
@@ -15,7 +13,7 @@ Keep `.verify.yml`, `script/verify`, and `.github/workflows/deploy.yml` aligned 
 
 **Thorough path** (routes, config, deps, app shell, metadata): plan → edit → `npx tsc --noEmit` → `npm run test:ci` → `npm run build:static` → visual check on affected routes.
 
-`npm run build:static` = `npm run build` + `npm run prerender`. Prerender needs Playwright Chromium (`npx playwright install chromium`). Prefer plain `npm run build` for the fast inner loop; use `build:static` or `./script/verify` when you need no-JS HTML snapshots in `dist/`.
+`npm run build:static` = `npm run build` + `npm run prerender` + `npm run assert:prerendered`. Prerender needs Playwright Chromium (`npx playwright install chromium`). Prefer plain `npm run build` for the fast inner loop; use `build:static` or `./script/verify` when you need no-JS HTML snapshots in `dist/`.
 
 ## When to run full verification
 
@@ -43,4 +41,5 @@ If routing behavior changes, update **both** `public/404.html` and the redirect 
 - Build/type errors: fix reported files; re-run `npx tsc --noEmit` and `npm run build`
 - Test failures: check `src/test/`; fix assertions or component behavior
 - Prerender failures: check `script/prerender.js` assertions; ensure Chromium is installed
-- Keep `CLAUDE.md` / `AGENTS.md` in sync if stack or verification steps change
+- Artifact check failures: `npm run assert:prerendered` — every sitemap route needs `data-prerendered` HTML under `dist/`
+- Keep `CLAUDE.md` / `AGENTS.md` / `.verify.yml` in sync if stack or verification steps change; edit `script/verify` (not `deploy.yml`) when the pipeline changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,23 +35,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Type check
-        run: npx tsc --noEmit
-
-      - name: Run lint
-        run: npm run lint
-
-      - name: Run tests
-        run: npm run test:ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
-
-      - name: Prerender routes
-        run: npm run prerender
+      # Single pipeline shared with local ./script/verify (CI=true → Chromium --with-deps).
+      - name: Run verification pipeline
+        run: bash script/verify --skip-install
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Prerender routes
+        run: npm run prerender
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.verify.yml
+++ b/.verify.yml
@@ -29,6 +29,16 @@ steps:
     required: true
     description: "Vite production build to dist/"
 
+  - name: "Install Playwright Chromium"
+    command: "npx playwright install chromium"
+    required: true
+    description: "Install Chromium for the prerender step (CI uses --with-deps)"
+
+  - name: "Prerender"
+    command: "npm run prerender"
+    required: true
+    description: "Snapshot routes into dist/ HTML via Playwright (self-asserts)"
+
 dev:
   command: "npm run dev"
   port: 5173
@@ -37,4 +47,6 @@ dev:
 agent_notes: |
   - Run script/verify for full verification
   - npm run build must produce dist/ with index.html, 404.html, CNAME
+  - npm run build:static = build + prerender (requires Playwright Chromium)
   - npm run test:ci runs Vitest with CI-friendly verbose output
+  - Adding a route: update siteRoutes registry and public/sitemap.xml (llms.txt too)

--- a/.verify.yml
+++ b/.verify.yml
@@ -1,13 +1,17 @@
 # Verification Configuration
-# Single source of truth for verification requirements.
+# Human/agent-readable contract. Executable implementation: ./script/verify
+# CI runs the same script after npm ci: bash script/verify --skip-install
 
 node_version: ">= 18.0.0"
+
+implementation: "./script/verify"
 
 steps:
   - name: "Install dependencies"
     command: "npm ci"
     required: true
-    description: "Install Node dependencies from lockfile"
+    skip_in_ci: true
+    description: "Install Node dependencies from lockfile (CI runs this before the script)"
 
   - name: "Type check"
     command: "npx tsc --noEmit"
@@ -32,12 +36,17 @@ steps:
   - name: "Install Playwright Chromium"
     command: "npx playwright install chromium"
     required: true
-    description: "Install Chromium for the prerender step (CI uses --with-deps)"
+    description: "Install Chromium for prerender (script adds --with-deps when CI=true)"
 
   - name: "Prerender"
     command: "npm run prerender"
     required: true
     description: "Snapshot routes into dist/ HTML via Playwright (self-asserts)"
+
+  - name: "Assert prerendered artifacts"
+    command: "npm run assert:prerendered"
+    required: true
+    description: "Every sitemap route has dist HTML with data-prerendered"
 
 dev:
   command: "npm run dev"
@@ -45,8 +54,9 @@ dev:
   url: "http://localhost:5173"
 
 agent_notes: |
-  - Run script/verify for full verification
+  - Run ./script/verify for full verification (do not re-list steps in deploy.yml)
+  - CI: npm ci then bash script/verify --skip-install
   - npm run build must produce dist/ with index.html, 404.html, CNAME
-  - npm run build:static = build + prerender (requires Playwright Chromium)
+  - npm run build:static = build + prerender + assert:prerendered (requires Playwright Chromium)
   - npm run test:ci runs Vitest with CI-friendly verbose output
   - Adding a route: update siteRoutes registry and public/sitemap.xml (llms.txt too)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This repository is a React 18 + Vite 6 + Tailwind CSS v4 single-page portfolio a
 **When executing commands:**
 
 - **If bash scripts are unavailable** (e.g., PowerShell environment): Execute the underlying Node/Vite commands directly:
-    - Instead of `./script/verify`, run: `npm ci` then `npx tsc --noEmit` then `npm run lint` then `npm run test:ci` then `npm run build` then `npx playwright install chromium` then `npm run prerender`
+    - Instead of `./script/verify`, run the steps listed in `.verify.yml` (see `script/verify` for the exact sequence, including Chromium install + prerender + `npm run assert:prerendered`)
     - Instead of `./script/dev`, run: `npm run dev`
 - **Read the scripts** (`script/verify`, `script/dev`) to understand what commands they execute, then run those commands directly in the available shell.
 - **Core Node/npm commands work in all shells** - the scripts are convenience wrappers, not requirements.
@@ -33,20 +33,20 @@ This repository is a React 18 + Vite 6 + Tailwind CSS v4 single-page portfolio a
 
 ### Source of Truth for Verification
 
-**`.verify.yml` is the single source of truth** for verification requirements. This declarative config file defines:
+**`.verify.yml` documents the contract; `./script/verify` is the executable implementation.** Local and CI both run that script (CI: `bash script/verify --skip-install` after `npm ci`). Do not re-list the same commands in `deploy.yml`.
+
+The config declares:
 
 - Required Node version (>= 18.0.0)
-- Verification steps (dependency installation, TypeScript type checking, lint, tests, production build, Playwright Chromium install, prerender)
+- Verification steps (dependency installation, TypeScript type checking, lint, tests, production build, Playwright Chromium install, prerender, prerender artifact assert)
 - Development server configuration
-
-Keep `.verify.yml`, `script/verify`, and `.github/workflows/deploy.yml` in sync when the pipeline changes.
 
 **Verification Execution:**
 
 - **Local development**: Run `./script/verify` to execute all verification steps
 - **Fast build loop**: `npm run build` only (no Chromium). Use `npm run build:static` when you need prerendered HTML in `dist/`
-- **Prerender prerequisite**: Playwright Chromium (`npx playwright install chromium`; CI uses `--with-deps`)
-- **CI**: Secondary verification layer, treated as final correctness signal on push/PR
+- **Prerender prerequisite**: Playwright Chromium (`npx playwright install chromium`; CI uses `--with-deps` via `CI=true`)
+- **CI**: Same pipeline as local via `script/verify --skip-install`
 - **Agent sandboxes**: May not be capable of running full builds/tests/prerender (Chromium + network) and should not block changes solely due to environment limitations
 
 ### Expected Agent Behavior

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This repository is a React 18 + Vite 6 + Tailwind CSS v4 single-page portfolio a
 **When executing commands:**
 
 - **If bash scripts are unavailable** (e.g., PowerShell environment): Execute the underlying Node/Vite commands directly:
-    - Instead of `./script/verify`, run: `npm ci` then `npx tsc --noEmit` then `npm run build`
+    - Instead of `./script/verify`, run: `npm ci` then `npx tsc --noEmit` then `npm run lint` then `npm run test:ci` then `npm run build` then `npx playwright install chromium` then `npm run prerender`
     - Instead of `./script/dev`, run: `npm run dev`
 - **Read the scripts** (`script/verify`, `script/dev`) to understand what commands they execute, then run those commands directly in the available shell.
 - **Core Node/npm commands work in all shells** - the scripts are convenience wrappers, not requirements.
@@ -36,14 +36,18 @@ This repository is a React 18 + Vite 6 + Tailwind CSS v4 single-page portfolio a
 **`.verify.yml` is the single source of truth** for verification requirements. This declarative config file defines:
 
 - Required Node version (>= 18.0.0)
-- Verification steps (dependency installation, TypeScript type checking, production build)
+- Verification steps (dependency installation, TypeScript type checking, lint, tests, production build, Playwright Chromium install, prerender)
 - Development server configuration
+
+Keep `.verify.yml`, `script/verify`, and `.github/workflows/deploy.yml` in sync when the pipeline changes.
 
 **Verification Execution:**
 
 - **Local development**: Run `./script/verify` to execute all verification steps
+- **Fast build loop**: `npm run build` only (no Chromium). Use `npm run build:static` when you need prerendered HTML in `dist/`
+- **Prerender prerequisite**: Playwright Chromium (`npx playwright install chromium`; CI uses `--with-deps`)
 - **CI**: Secondary verification layer, treated as final correctness signal on push/PR
-- **Agent sandboxes**: May not be capable of running full builds/tests and should not block changes solely due to environment limitations
+- **Agent sandboxes**: May not be capable of running full builds/tests/prerender (Chromium + network) and should not block changes solely due to environment limitations
 
 ### Expected Agent Behavior
 
@@ -57,7 +61,8 @@ When making changes:
    - After editing TypeScript/JavaScript files: Run `npm run lint:js`
    - Use `npm run lint:fix` to auto-fix issues, but always review changes
    - If npm is unavailable, note linting verification in output
-5. If tests/build cannot be run due to environment restrictions:
+5. **Adding a route:** update `src/app/content/siteRoutes.ts` (or project registry) **and** `public/sitemap.xml` / `public/llms.txt`. Prerender derives paths from `dist/sitemap.xml`.
+6. If tests/build cannot be run due to environment restrictions:
    - Read `.verify.yml` to understand verification requirements
    - Provide the patch and note: "Verify locally with: ./script/verify"
    - Reference the verification steps from `.verify.yml` in your output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,15 @@ npm ci
 npx tsc --noEmit
 npm run test:ci
 npm run build
+npx playwright install chromium   # once per machine / CI image
+npm run prerender
 # or
 ./script/verify
+```
+
+For a production-like static snapshot without the full verify pipeline:
+```bash
+npm run build:static   # build + prerender (requires Playwright Chromium)
 ```
 
 ### Preview production build
@@ -42,6 +49,7 @@ npm run preview
 - Router: `BrowserRouter`
 - Routes:
   - `/`
+  - `/about`
   - `/projects/walkability-index`
   - `/projects/replacement-trap`
   - `/projects/bantr`
@@ -63,9 +71,12 @@ npm run preview
 Project content is route-component based.
 
 - Each project is implemented as a React component in `src/app/projects/`
+- Canonical route list: `src/app/content/siteRoutes.ts` (feeds sitemap / prerender via `public/sitemap.xml`)
 - Additions require:
   - New component file in `src/app/projects/`
   - Route registration in `src/app/App.tsx`
+  - Entry in `siteRoutes` / `selectedWorkProjects` as appropriate
+  - Updates to `public/sitemap.xml` and `public/llms.txt` (drift-tested)
   - Any card/link surface updates in homepage components
 
 ## Testing
@@ -83,9 +94,12 @@ GitHub Actions workflow: `.github/workflows/deploy.yml`
 Build job:
 1. `npm ci`
 2. `npx tsc --noEmit`
-3. `npm run test:ci`
-4. `npm run build`
-5. Upload `dist/` artifact
+3. `npm run lint`
+4. `npm run test:ci`
+5. `npm run build`
+6. `npx playwright install --with-deps chromium`
+7. `npm run prerender`
+8. Upload `dist/` artifact
 
 Deploy job:
 - Runs only on push to `main`
@@ -96,6 +110,8 @@ Static deploy-critical files:
 - `public/404.html`
 - `public/favicon.ico`
 - `public/robots.txt`
+- `public/sitemap.xml`
+- `public/llms.txt`
 
 ## Conventions
 
@@ -103,6 +119,8 @@ Static deploy-critical files:
 - Do not change dependency versions unless requested.
 - Preserve root-deploy assumptions (no base path/basename).
 - If SPA routing behavior changes, update both `public/404.html` and `index.html` decoder logic together.
+- Prefer `npm run build` for the fast inner loop; use `npm run build:static` (or `./script/verify`) when you need prerendered HTML. Prerender requires Playwright Chromium (`npx playwright install chromium`).
+- Adding a route: update the `siteRoutes` registry **and** `public/sitemap.xml` (and `llms.txt`). Prerender reads routes from `dist/sitemap.xml` — no hardcoded route list in the script.
 
 ## Related Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,19 +21,14 @@ npm run dev
 
 ### Verification
 ```bash
-npm ci
-npx tsc --noEmit
-npm run test:ci
-npm run build
-npx playwright install chromium   # once per machine / CI image
-npm run prerender
-# or
 ./script/verify
+# or (after npm ci, same pipeline CI uses):
+bash script/verify --skip-install
 ```
 
 For a production-like static snapshot without the full verify pipeline:
 ```bash
-npm run build:static   # build + prerender (requires Playwright Chromium)
+npm run build:static   # build + prerender + assert:prerendered (requires Playwright Chromium)
 ```
 
 ### Preview production build
@@ -93,13 +88,8 @@ GitHub Actions workflow: `.github/workflows/deploy.yml`
 
 Build job:
 1. `npm ci`
-2. `npx tsc --noEmit`
-3. `npm run lint`
-4. `npm run test:ci`
-5. `npm run build`
-6. `npx playwright install --with-deps chromium`
-7. `npm run prerender`
-8. Upload `dist/` artifact
+2. `bash script/verify --skip-install` (typecheck, lint, test, build, Chromium, prerender, assert prerendered)
+3. Upload `dist/` artifact
 
 Deploy job:
 - Runs only on push to `main`
@@ -121,6 +111,7 @@ Static deploy-critical files:
 - If SPA routing behavior changes, update both `public/404.html` and `index.html` decoder logic together.
 - Prefer `npm run build` for the fast inner loop; use `npm run build:static` (or `./script/verify`) when you need prerendered HTML. Prerender requires Playwright Chromium (`npx playwright install chromium`).
 - Adding a route: update the `siteRoutes` registry **and** `public/sitemap.xml` (and `llms.txt`). Prerender reads routes from `dist/sitemap.xml` — no hardcoded route list in the script.
+- Verification pipeline lives in `./script/verify`; `.github/workflows/deploy.yml` calls it — do not duplicate steps in the workflow.
 
 ## Related Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This project is optimized for small, targeted changes with strong local verifica
 
 - Read `CLAUDE.md` for architecture and route/content conventions.
 - Read `AGENTS.md` for environment constraints and verification expectations.
-- Use `.verify.yml` as the source of truth for required checks.
+- Use `.verify.yml` as the readable contract; run `./script/verify` (CI uses the same script).
 - Review focused guidance in `.cursor/rules/`.
 
 ## Development Workflow
@@ -14,10 +14,8 @@ This project is optimized for small, targeted changes with strong local verifica
 1. Create a focused branch.
 2. Make the smallest change that solves the problem.
 3. Run local verification:
-   - `npm run lint`
-   - `npx tsc --noEmit`
-   - `npm run test:ci`
-   - `npm run build`
+   - Prefer `./script/verify` (full pipeline including prerender)
+   - Or the fast path: `npm run lint`, `npx tsc --noEmit`, `npm run test:ci`, `npm run build`
 4. Open a PR with a concise summary and test notes.
 
 If you cannot run bash scripts in your shell, run the npm commands directly instead of `./script/*`.

--- a/README.md
+++ b/README.md
@@ -81,26 +81,31 @@ Before pushing changes, run the verification script:
 ./script/verify
 ```
 
-This script:
+This is the single executable pipeline (local and CI). It:
 
 - Installs dependencies (`npm ci`)
-- Runs TypeScript type checking (`npx tsc --noEmit`)
-- Runs tests (`npm run test:ci`)
+- Type-checks, lints, and runs tests
 - Builds the production bundle (`npm run build`)
+- Installs Playwright Chromium and prerenders every sitemap route
+- Asserts each route’s HTML under `dist/` has `data-prerendered`
+
+For a production-like static snapshot without the full verify suite:
+
+```bash
+npm run build:static   # build + prerender + assert (requires Playwright Chromium)
+```
 
 **Verification Configuration:**
 
-See `.verify.yml` for the complete verification contract. This file serves as the single source of truth for what needs to be verified, readable by both humans and AI agents.
+See `.verify.yml` for the human/agent-readable contract. `./script/verify` is the implementation — CI calls the same script so steps cannot drift from `deploy.yml`.
 
 **CI/CD:**
 
-GitHub Actions runs full verification on push/PR to catch issues automatically. The workflow:
+GitHub Actions (`.github/workflows/deploy.yml`) on push/PR:
 
-1. Installs dependencies
-2. Runs type checking
-3. Runs tests (non-blocking)
-4. Builds the production bundle
-5. Deploys to GitHub Pages (on push to `main`)
+1. Installs dependencies (`npm ci`)
+2. Runs `bash script/verify --skip-install` (same pipeline as local)
+3. Uploads `dist/` and deploys to GitHub Pages (on push to `main` only)
 
 ### Testing
 
@@ -164,9 +169,11 @@ Linters are configured to ignore minified files and vendor libraries. Configurat
 
 ```text
 .
-├── .verify.yml          # Verification configuration (single source of truth)
+├── .verify.yml          # Verification contract (agents/humans); implemented by script/verify
 ├── script/              # Development scripts
-│   ├── verify           # Verification script
+│   ├── verify           # Verification pipeline (local + CI)
+│   ├── prerender.js     # Post-build Playwright route snapshots
+│   ├── assert-prerendered.js  # Post-prerender dist/ gate
 │   └── dev              # Development server script
 ├── src/                 # Source code
 │   ├── app/             # Application code
@@ -222,9 +229,10 @@ Linters are configured to ignore minified files and vendor libraries. Configurat
 
 ### Routing
 
-The app uses React Router's `BrowserRouter` for client-side routing. Routes are defined in `src/app/App.tsx`:
+The app uses React Router's `BrowserRouter` for client-side routing. Routes are defined in `src/app/App.tsx` (canonical list in `src/app/content/siteRoutes.ts`):
 
 - `/` - Homepage
+- `/about` - About
 - `/projects/walkability-index` - Walkability Index project
 - `/projects/replacement-trap` - Replacement Trap project
 - `/projects/bantr` - Bantr project
@@ -248,8 +256,8 @@ Since GitHub Pages doesn't natively support SPAs, the project includes:
 
 The site is deployed to GitHub Pages via GitHub Actions (`.github/workflows/deploy.yml`). The workflow:
 
-1. Builds the production bundle to `dist/`
-2. Deploys to GitHub Pages on push to `main`
+1. Runs the shared verification pipeline (build + prerender into `dist/`)
+2. Deploys the artifact to GitHub Pages on push to `main`
 
 Static deploy-critical files in `public/`:
 
@@ -257,6 +265,7 @@ Static deploy-critical files in `public/`:
 - `404.html` - SPA routing fallback
 - `favicon.ico` - Site favicon
 - `robots.txt` - Search engine directives
+- `sitemap.xml` / `llms.txt` - Discovery files (copied into `dist/`)
 
 ## Contact
 - **Website:** [grantgeist.com](https://grantgeist.com)

--- a/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
+++ b/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
@@ -7,8 +7,9 @@
 | 1 | Discovery files (`sitemap.xml`, `llms.txt`, `siteRoutes`, drift test) | **Merged** (#27) |
 | 2 | Per-route document metadata | **Merged** (#28) |
 | 3 | Prerender script | **Merged** (#29) |
-| 4 | Wire prerender into CI / verify contract | In progress on `feat/wire-prerender-ci` (#30) |
+| 4 | Wire prerender into CI / verify contract | **Done** on `feat/wire-prerender-ci` — open as #30; not yet merged |
 | 5 | Retire SPA redirect hack | Not started |
+
 
 ---
 
@@ -26,7 +27,7 @@ These were verified against the repo and drive several non-obvious choices:
 
 - **`tsconfig.json` is `include: ["src"]`, and `@types/node` is not installed.** A script outside `src/` is not typechecked and cannot be `.ts` without adding a dependency — which `AGENTS.md:52-54` forbids unrequested. Same constraint blocked `node:fs` in the PR 1 drift test (see below).
 - **ESLint is a CI gate** (`eslint . --max-warnings=0`) and grants `globals.node` only to `files: ["**/*.{ts,tsx,js,jsx}"]` ([eslint.config.mjs:14-21](eslint.config.mjs#L14-L21)). A `.mjs` script using `process`/`fs` would fail `no-undef`; a `.js` script gets Node globals free and is an ES module via `"type": "module"`. **So the prerender script must be `.js`.**
-- **Tests run before build** in [deploy.yml](.github/workflows/deploy.yml) and `script/verify`. A Vitest test asserting on `dist/` output would pass vacuously on a clean checkout. The prerender script must therefore self-assert and exit non-zero.
+- **Tests run before build** in `script/verify` (and therefore CI). A Vitest test asserting on `dist/` output would pass vacuously on a clean checkout. The prerender script must therefore self-assert and exit non-zero; PR 4 also adds a post-write `assert:prerendered` gate.
 - **`vite preview` serves extensionless paths from the pristine `dist/index.html`** (sirv runs with `extensions: []`), so prerendering is naturally idempotent per project route. `/` is the exception since we overwrite `dist/index.html` — needs an explicit guard.
 - `public/robots.txt` advertises `/sitemap.xml`. **PR 1 added `public/sitemap.xml`** (and removed the dead root `robots.txt`). Live 404 clears once that branch deploys.
 - Every indexable route now has exactly one `<h1>` (PR 2 promoted About's heading). Hero + CaseStudyHero remain the other `h1` sources.
@@ -89,8 +90,8 @@ JSON-LD: `Person` + `WebSite` on `/`, `Person` on `/about`, `CreativeWork` + `Br
 - Stopped pointing `og:image` at project `.webp` thumbnails.
 - Deduplicated `absoluteUrl` into a single export from `routeMetadata.ts`.
 
-**Known residual (closes with PR 4 deploy)**
-- Until prerender is wired into CI and deployed, no-JS social scrapers still miss OG tags on first paint (static `og:*` removed from `index.html` by design). Google executes JS; PR 3's snapshots close the gap once PR 4 ships them.
+**Known residual (closes when PR 4 deploys to main)**
+- Until #30 merges and Pages deploys, production still serves pre-prerender HTML — no-JS social scrapers miss OG tags on first paint (static `og:*` removed from `index.html` by design). Google executes JS; prerendered snapshots close the gap once #30 lands on `main`.
 - Unknown paths reuse home title/description with a pathname-specific canonical; PR 5's real 404 should add `noindex` + distinct copy.
 
 **Verify (done):** `npx tsc --noEmit && npm run lint:js && npm run test:ci` (document-meta + full suite green after review fixes).
@@ -111,7 +112,7 @@ Ships alone, changes nothing in production until PR 4. All the risk lives here, 
 - `src/test/local-assets.test.ts` — drift test: noise SVG exists (`?raw`) and Hero references `/assets/noise.svg`, not an external host.
 
 **Modified**
-- `package.json` — add `"prerender": "node script/prerender.js"` and `"build:static": "npm run build && npm run prerender"`. No dependency changes.
+- `package.json` — add `"prerender": "node script/prerender.js"` and `"build:static": "npm run build && npm run prerender"` (PR 4 later appends `assert:prerendered`). No dependency changes.
 - [Hero.tsx](src/app/components/Hero.tsx) — card overlay `bg-[url('/assets/noise.svg')]`.
 
 **Deliberately not a `postbuild` hook:** that would require Chromium binaries for every local `npm run build`, slow the documented fast inner loop, and break the restricted-network agent sandbox contract in `AGENTS.md:9-11`.
@@ -143,25 +144,38 @@ Results buffer in a `Map` and write only after **all** routes pass. Output is di
 
 **Risk:** Highest-complexity PR, but zero production impact until PR 4. Review focus: wait ladder, idempotency guard, `close()` ordering.
 
-**Next:** PR 4 (wire into CI / verify) — in progress on `feat/wire-prerender-ci`.
+**Next:** merge #30, then PR 5 (retire SPA redirect) after live curl checks.
 
 ---
 
-## PR 4 — Wire into CI and update the verification contract
+## PR 4 — Wire into CI and update the verification contract ✅ (not yet merged)
 
-**Branch:** `feat/wire-prerender-ci`
+**Branch:** `feat/wire-prerender-ci` → open as #30.
+
+**Goal:** ship prerendered HTML in the Pages artifact, and stop hand-duplicating the verify pipeline across three files.
+
+**Added**
+- `script/assert-prerendered.js` + `npm run assert:prerendered` — parses `dist/sitemap.xml`, asserts every route’s directory-form HTML exists under `dist/` and carries `data-prerendered`. Fail-loud for CI / `build:static`.
 
 **Modified**
-- [deploy.yml](.github/workflows/deploy.yml) — after `npm ci`, run `bash script/verify --skip-install` (same pipeline as local; `CI=true` adds Chromium `--with-deps`), then upload artifact. No duplicated typecheck/lint/test/build/prerender steps in the workflow.
-- `script/verify` — single executable pipeline; supports `--skip-install` for CI.
-- `script/assert-prerendered.js` + `npm run assert:prerendered` — every sitemap route must have `data-prerendered` HTML under `dist/`.
-- `.verify.yml`, `README.md`, `CLAUDE.md`, `AGENTS.md`, `.cursor/rules/iteration-workflow.mdc`, `CONTRIBUTING.md` — document shared pipeline, `build:static`, Chromium, and route/sitemap update path.
+- [deploy.yml](.github/workflows/deploy.yml) — after `npm ci`, run `bash script/verify --skip-install`, then upload artifact. No duplicated typecheck/lint/test/build/prerender steps in the workflow. `CI=true` makes the script install Chromium with `--with-deps`.
+- `script/verify` — single executable pipeline for local + CI; supports `--skip-install`; Chromium / prerender / assert steps included.
+- `package.json` — `build:static` is now `build && prerender && assert:prerendered`.
+- `.verify.yml` — documents the contract and points at `./script/verify` as the implementation (`implementation:` field; CI note for `--skip-install`).
+- `README.md`, `CLAUDE.md`, `AGENTS.md`, `.cursor/rules/iteration-workflow.mdc`, `CONTRIBUTING.md` — document shared pipeline, `build:static`, Chromium prerequisite, and that adding a route updates the registry *and* `public/sitemap.xml` / `llms.txt`.
+
+**Deviations / review hardening (same PR)**
+- First pass duplicated Chromium + prerender into `deploy.yml`, `.verify.yml`, and `script/verify`. Follow-up collapsed CI onto `script/verify --skip-install` so steps cannot drift.
+- Added automated artifact gate (`assert:prerendered`) instead of relying on manual Actions log inspection alone.
+- Updated user-facing `README.md` (was still describing the pre-prerender verify/CI story, including an incorrect “tests non-blocking” claim).
 
 Skip Playwright browser caching for now — a stale cache key is a confusing failure mode, and it's an optimization for after the pipeline is proven.
 
-**Verify:** read the PR's Actions log; confirm prerender + assert steps pass and the uploaded artifact contains six prerendered HTML files; note wall-clock time.
+**Verify (done on #30 Actions):** build job ~1m20s; `script/verify --skip-install` prerendered 6 routes; `assert:prerendered` passed; deploy skipped on PR (expected). Production impact still gated on merge to `main`.
 
-**Risk:** First production deploy of prerendered HTML. Mitigated by the PR run proving it pre-merge.
+**Risk:** First production deploy of prerendered HTML. Mitigated by the PR run proving the pipeline pre-merge.
+
+**Next:** merge #30 → live smoke of all six routes → PR 5.
 
 ---
 

--- a/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
+++ b/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
@@ -6,8 +6,8 @@
 |----|-------|--------|
 | 1 | Discovery files (`sitemap.xml`, `llms.txt`, `siteRoutes`, drift test) | **Merged** (#27) |
 | 2 | Per-route document metadata | **Merged** (#28) |
-| 3 | Prerender script | **Done** on `feat/prerender-script` — open as #29; not yet merged |
-| 4 | Wire prerender into CI / verify contract | Not started |
+| 3 | Prerender script | **Merged** (#29) |
+| 4 | Wire prerender into CI / verify contract | In progress on `feat/wire-prerender-ci` |
 | 5 | Retire SPA redirect hack | Not started |
 
 ---
@@ -99,11 +99,11 @@ JSON-LD: `Person` + `WebSite` on `/`, `Person` on `/about`, `CreativeWork` + `Br
 
 ---
 
-## PR 3 — The prerender script ✅ (not yet wired into CI)
+## PR 3 — The prerender script ✅
 
 Ships alone, changes nothing in production until PR 4. All the risk lives here, isolated.
 
-**Branch:** `feat/prerender-script` → open as #29.
+**Branch:** `feat/prerender-script` → merged via #29.
 
 **Added**
 - `script/prerender.js` — sits beside the existing `script/dev` and `script/verify`.
@@ -143,15 +143,17 @@ Results buffer in a `Map` and write only after **all** routes pass. Output is di
 
 **Risk:** Highest-complexity PR, but zero production impact until PR 4. Review focus: wait ladder, idempotency guard, `close()` ordering.
 
-**Next:** merge #29, then PR 4 (wire into CI / verify).
+**Next:** PR 4 (wire into CI / verify) — in progress on `feat/wire-prerender-ci`.
 
 ---
 
 ## PR 4 — Wire into CI and update the verification contract
 
+**Branch:** `feat/wire-prerender-ci`
+
 **Modified**
 - [deploy.yml](.github/workflows/deploy.yml) — after `npm run build`, add `npx playwright install --with-deps chromium` then `npm run prerender`, before `upload-pages-artifact`. Adds roughly 45-90s per run. Runs on PRs too (the build job has no branch guard), so **this PR verifies itself in its own Actions log**.
-- `.verify.yml`, `script/verify` — add the prerender step. These plus `deploy.yml` hand-duplicate the same pipeline in three places, and `.cursor/rules/iteration-workflow.mdc` requires keeping them in sync.
+- `.verify.yml`, `script/verify` — add Chromium install + prerender steps. These plus `deploy.yml` hand-duplicate the same pipeline in three places, and `.cursor/rules/iteration-workflow.mdc` requires keeping them in sync.
 - `CLAUDE.md`, `AGENTS.md`, `.cursor/rules/iteration-workflow.mdc` — document `build:static`, the Chromium prerequisite, and that adding a route means updating the registry *and* `public/sitemap.xml`.
 
 Skip Playwright browser caching for now — a stale cache key is a confusing failure mode, and it's an optimization for after the pipeline is proven.

--- a/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
+++ b/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
@@ -7,7 +7,7 @@
 | 1 | Discovery files (`sitemap.xml`, `llms.txt`, `siteRoutes`, drift test) | **Merged** (#27) |
 | 2 | Per-route document metadata | **Merged** (#28) |
 | 3 | Prerender script | **Merged** (#29) |
-| 4 | Wire prerender into CI / verify contract | In progress on `feat/wire-prerender-ci` |
+| 4 | Wire prerender into CI / verify contract | In progress on `feat/wire-prerender-ci` (#30) |
 | 5 | Retire SPA redirect hack | Not started |
 
 ---
@@ -152,13 +152,14 @@ Results buffer in a `Map` and write only after **all** routes pass. Output is di
 **Branch:** `feat/wire-prerender-ci`
 
 **Modified**
-- [deploy.yml](.github/workflows/deploy.yml) — after `npm run build`, add `npx playwright install --with-deps chromium` then `npm run prerender`, before `upload-pages-artifact`. Adds roughly 45-90s per run. Runs on PRs too (the build job has no branch guard), so **this PR verifies itself in its own Actions log**.
-- `.verify.yml`, `script/verify` — add Chromium install + prerender steps. These plus `deploy.yml` hand-duplicate the same pipeline in three places, and `.cursor/rules/iteration-workflow.mdc` requires keeping them in sync.
-- `CLAUDE.md`, `AGENTS.md`, `.cursor/rules/iteration-workflow.mdc` — document `build:static`, the Chromium prerequisite, and that adding a route means updating the registry *and* `public/sitemap.xml`.
+- [deploy.yml](.github/workflows/deploy.yml) — after `npm ci`, run `bash script/verify --skip-install` (same pipeline as local; `CI=true` adds Chromium `--with-deps`), then upload artifact. No duplicated typecheck/lint/test/build/prerender steps in the workflow.
+- `script/verify` — single executable pipeline; supports `--skip-install` for CI.
+- `script/assert-prerendered.js` + `npm run assert:prerendered` — every sitemap route must have `data-prerendered` HTML under `dist/`.
+- `.verify.yml`, `README.md`, `CLAUDE.md`, `AGENTS.md`, `.cursor/rules/iteration-workflow.mdc`, `CONTRIBUTING.md` — document shared pipeline, `build:static`, Chromium, and route/sitemap update path.
 
 Skip Playwright browser caching for now — a stale cache key is a confusing failure mode, and it's an optimization for after the pipeline is proven.
 
-**Verify:** read the PR's Actions log; confirm the uploaded artifact contains six prerendered HTML files and note the added wall-clock time.
+**Verify:** read the PR's Actions log; confirm prerender + assert steps pass and the uploaded artifact contains six prerendered HTML files; note wall-clock time.
 
 **Risk:** First production deploy of prerendered HTML. Mitigated by the PR run proving it pre-merge.
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "build:static": "npm run build && npm run prerender",
+    "build:static": "npm run build && npm run prerender && npm run assert:prerendered",
     "prerender": "node script/prerender.js",
+    "assert:prerendered": "node script/assert-prerendered.js",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/script/assert-prerendered.js
+++ b/script/assert-prerendered.js
@@ -1,0 +1,91 @@
+/**
+ * Post-prerender gate: every sitemap route must have directory-form HTML
+ * under dist/ marked with data-prerendered. Fail-loud for CI / verify.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const DIST = join(ROOT, "dist");
+const SITEMAP_PATH = join(DIST, "sitemap.xml");
+
+/**
+ * @param {string} sitemapXml
+ * @returns {string[]}
+ */
+function pathsFromSitemap(sitemapXml) {
+  const locs = [...sitemapXml.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/g)].map(
+    (m) => m[1].trim()
+  );
+
+  if (locs.length === 0) {
+    throw new Error(`No <loc> entries found in ${SITEMAP_PATH}`);
+  }
+
+  return locs.map((loc) => {
+    let url;
+    try {
+      url = new URL(loc);
+    } catch {
+      throw new Error(`Invalid <loc> URL in sitemap: ${loc}`);
+    }
+    const path = url.pathname || "/";
+    return path.endsWith("/") && path !== "/" ? path.slice(0, -1) : path;
+  });
+}
+
+/** @param {string} pathname */
+function outputPathFor(pathname) {
+  if (pathname === "/") {
+    return join(DIST, "index.html");
+  }
+  return join(DIST, pathname.replace(/^\//, ""), "index.html");
+}
+
+function main() {
+  if (!existsSync(SITEMAP_PATH)) {
+    throw new Error(
+      `Missing ${SITEMAP_PATH}. Run \`npm run build\` (and prerender) first.`
+    );
+  }
+
+  const paths = pathsFromSitemap(readFileSync(SITEMAP_PATH, "utf8"));
+  /** @type {string[]} */
+  const failures = [];
+
+  for (const pathname of paths) {
+    const outPath = outputPathFor(pathname);
+    const rel = relative(ROOT, outPath).replaceAll("\\", "/");
+
+    if (!existsSync(outPath)) {
+      failures.push(`${pathname}: missing ${rel}`);
+      continue;
+    }
+
+    const html = readFileSync(outPath, "utf8");
+    if (!html.includes("data-prerendered")) {
+      failures.push(`${pathname}: ${rel} lacks data-prerendered`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Prerender artifact check failed (${failures.length}/${paths.length}):\n` +
+        failures.map((f) => `  - ${f}`).join("\n")
+    );
+  }
+
+  console.log(
+    `Prerender artifact check passed: ${paths.length} routes have data-prerendered HTML.`
+  );
+}
+
+try {
+  main();
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(message);
+  process.exit(1);
+}

--- a/script/verify
+++ b/script/verify
@@ -24,7 +24,7 @@ for arg in "$@"; do
   case "$arg" in
     --skip-install) SKIP_INSTALL=1 ;;
     -h|--help)
-      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,9p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *)

--- a/script/verify
+++ b/script/verify
@@ -52,5 +52,21 @@ else
     exit 1
 fi
 
+echo -e "\n${BLUE}Step 6: Installing Playwright Chromium...${NC}"
+if npx playwright install chromium; then
+    echo -e "${GREEN}Chromium installed${NC}"
+else
+    echo -e "${RED}Failed to install Playwright Chromium${NC}"
+    exit 1
+fi
+
+echo -e "\n${BLUE}Step 7: Prerendering routes...${NC}"
+if npm run prerender; then
+    echo -e "${GREEN}Prerender succeeded${NC}"
+else
+    echo -e "${RED}Prerender failed${NC}"
+    exit 1
+fi
+
 echo -e "\n${GREEN}All verification steps passed!${NC}"
 exit 0

--- a/script/verify
+++ b/script/verify
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
-# Verification script — Node/Vite build pipeline
+# Verification pipeline — single executable contract for local + CI.
+# Declared for agents in .verify.yml; do not duplicate steps in deploy.yml.
+#
+# Usage:
+#   ./script/verify              # full local run (includes npm ci)
+#   ./script/verify --skip-install  # CI after setup-node + npm ci
+#
+# Chromium: adds --with-deps when CI=true or PLAYWRIGHT_WITH_DEPS=1.
 set -euo pipefail
 
 RED='\033[0;31m'
@@ -12,61 +19,56 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$REPO_ROOT"
 
-echo -e "${BLUE}Step 1: Installing dependencies...${NC}"
-if npm ci; then
-    echo -e "${GREEN}Dependencies installed${NC}"
-else
-    echo -e "${RED}Failed to install dependencies${NC}"
+SKIP_INSTALL=0
+for arg in "$@"; do
+  case "$arg" in
+    --skip-install) SKIP_INSTALL=1 ;;
+    -h|--help)
+      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo -e "${RED}Unknown argument: $arg${NC}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+step=0
+run_step() {
+  local label=$1
+  shift
+  step=$((step + 1))
+  echo -e "\n${BLUE}Step ${step}: ${label}...${NC}"
+  if "$@"; then
+    echo -e "${GREEN}${label} passed${NC}"
+  else
+    echo -e "${RED}${label} failed${NC}"
     exit 1
+  fi
+}
+
+if [[ "$SKIP_INSTALL" -eq 0 ]]; then
+  run_step "Installing dependencies" npm ci
+else
+  echo -e "${BLUE}Skipping dependency install (--skip-install)${NC}"
 fi
 
-echo -e "\n${BLUE}Step 2: Type checking...${NC}"
-if npx tsc --noEmit; then
-    echo -e "${GREEN}Type check passed${NC}"
+run_step "Type checking" npx tsc --noEmit
+run_step "Linting" npm run lint
+run_step "Running tests" npm run test:ci
+run_step "Building" npm run build
+
+if [[ "${CI:-}" == "true" || "${PLAYWRIGHT_WITH_DEPS:-}" == "1" ]]; then
+  run_step "Installing Playwright Chromium (with OS deps)" \
+    npx playwright install --with-deps chromium
 else
-    echo -e "${RED}Type check failed${NC}"
-    exit 1
+  run_step "Installing Playwright Chromium" \
+    npx playwright install chromium
 fi
 
-echo -e "\n${BLUE}Step 3: Linting...${NC}"
-if npm run lint; then
-    echo -e "${GREEN}Lint passed${NC}"
-else
-    echo -e "${RED}Lint failed${NC}"
-    exit 1
-fi
-
-echo -e "\n${BLUE}Step 4: Running tests...${NC}"
-if npm run test:ci; then
-    echo -e "${GREEN}Tests passed${NC}"
-else
-    echo -e "${RED}Tests failed${NC}"
-    exit 1
-fi
-
-echo -e "\n${BLUE}Step 5: Building...${NC}"
-if npm run build; then
-    echo -e "${GREEN}Build succeeded${NC}"
-else
-    echo -e "${RED}Build failed${NC}"
-    exit 1
-fi
-
-echo -e "\n${BLUE}Step 6: Installing Playwright Chromium...${NC}"
-if npx playwright install chromium; then
-    echo -e "${GREEN}Chromium installed${NC}"
-else
-    echo -e "${RED}Failed to install Playwright Chromium${NC}"
-    exit 1
-fi
-
-echo -e "\n${BLUE}Step 7: Prerendering routes...${NC}"
-if npm run prerender; then
-    echo -e "${GREEN}Prerender succeeded${NC}"
-else
-    echo -e "${RED}Prerender failed${NC}"
-    exit 1
-fi
+run_step "Prerendering routes" npm run prerender
+run_step "Checking prerender artifacts" npm run assert:prerendered
 
 echo -e "\n${GREEN}All verification steps passed!${NC}"
 exit 0


### PR DESCRIPTION
## Summary
- Run Playwright Chromium install + `npm run prerender` after build in `deploy.yml`, so Pages artifacts include no-JS HTML for all sitemap routes.
- Keep `.verify.yml` and `script/verify` in sync with the same post-build steps.
- Document `build:static`, the Chromium prerequisite, and the siteRoutes + sitemap update path in `CLAUDE.md`, `AGENTS.md`, and `iteration-workflow.mdc`.

## Test plan
- [ ] Confirm CI build job installs Chromium and runs prerender successfully
- [ ] Confirm uploaded Pages artifact includes six prerendered HTML files (`dist/index.html`, `dist/about/index.html`, and the four `dist/projects/*/index.html`)
- [ ] Note wall-clock added by Chromium install + prerender (~45–90s expected)
- [ ] Spot-check one project HTML in the artifact for `<h1>`, canonical, and JSON-LD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI/deploy path and what ships to GitHub Pages (prerendered HTML); mitigated by the assert gate and running the same pipeline on PRs, but merge to main is the first production prerender deploy.
> 
> **Overview**
> **Unifies local and CI verification** so GitHub Pages ships prerendered HTML instead of duplicating steps in `deploy.yml`. After `npm ci`, the workflow runs `bash script/verify --skip-install` only; typecheck, lint, test, build, Playwright Chromium, prerender, and artifact checks all live in `./script/verify`.
> 
> **`script/verify`** gains `--skip-install`, post-build **Chromium install** (`--with-deps` when `CI=true`), **`npm run prerender`**, and **`npm run assert:prerendered`**. **`.verify.yml`** documents that contract and points at the script as the implementation.
> 
> Adds **`script/assert-prerendered.js`** and **`npm run assert:prerendered`**, which reads `dist/sitemap.xml` and fails if any route is missing directory-form HTML with `data-prerendered`. **`npm run build:static`** now runs build → prerender → assert.
> 
> Docs (`README`, `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING`, iteration workflow, session plan) describe the shared pipeline, `build:static`, Chromium prerequisites, and keeping routes in sync via `siteRoutes` + `public/sitemap.xml` / `llms.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce0d7d13a858ef61538009510cf64648045d9a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->