### PR TITLE
Retire SPA redirect; ship a real static 404

### DIFF
--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -54,7 +54,7 @@ Canonical overview and verification live in `CLAUDE.md`, `AGENTS.md`, and `.veri
 - Components, routes, content model, app architecture
 
 ### `iteration-workflow.mdc`
-- When to run full vs light verification; SPA routing sync notes
+- When to run full vs light verification; routing / prerender / 404 notes
 
 ### `file-naming.mdc`
 - PascalCase components, kebab UI primitives, snake_case assets/docs

--- a/.cursor/rules/asset-management.mdc
+++ b/.cursor/rules/asset-management.mdc
@@ -16,7 +16,7 @@ Files in `public/` are served at the site root. Reference them with paths starti
 
 ```text
 public/
-├── 404.html          # SPA fallback for GitHub Pages
+├── 404.html          # Static not-found page for unknown paths
 ├── CNAME             # Custom domain
 ├── favicon.ico
 ├── robots.txt
@@ -61,7 +61,7 @@ Images/CSS/SVG imported in components are handled by Vite (hashing, bundling). U
 These must remain in `public/` for GitHub Pages:
 
 - `CNAME` – custom domain
-- `404.html` – SPA redirect/decoder for client-side routing
+- `404.html` – Static not-found page (`noindex`); known routes are prerendered files
 - `favicon.ico`, `robots.txt` – as desired
 
 Do not remove or rename these without updating deployment and routing docs.

--- a/.cursor/rules/iteration-workflow.mdc
+++ b/.cursor/rules/iteration-workflow.mdc
@@ -32,9 +32,9 @@ Light check (visual + build) is enough for copy-only, styling tweaks, or small U
 
 Adding a route requires updating the `siteRoutes` registry **and** `public/sitemap.xml` (and `public/llms.txt`). Prerender reads paths from `dist/sitemap.xml` — do not hardcode a second route list.
 
-## SPA routing
+## Routing and 404s
 
-If routing behavior changes, update **both** `public/404.html` and the redirect decoder in `index.html`.
+Known routes are prerendered into `dist/` as directory-form HTML. `public/404.html` is a static not-found page (with `noindex`) for unknown paths — do not reintroduce a SPA `sessionStorage` redirect. Adding or renaming a route still requires the registry + `sitemap.xml` / `llms.txt` updates above so prerender emits the new file.
 
 ## Error handling
 

--- a/.cursor/rules/react-structure.mdc
+++ b/.cursor/rules/react-structure.mdc
@@ -41,7 +41,7 @@ Projects are route-based React components, not markdown or CMS.
 
 - Use `BrowserRouter`; no basename (root deploy).
 - Project paths: `/projects/walkability-index`, `/projects/bantr`, etc. (kebab-case).
-- Deep links work via `public/404.html` + redirect decoder in `index.html`.
+- Deep links are prerendered HTML under `dist/`; `public/404.html` is a static not-found page for unknown paths.
 
 ### Component Organization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is a React 18 + Vite 6 + Tailwind CSS v4 single-page portfolio app deployed
 
 - Root deploy (no `base` in `vite.config.ts`)
 - BrowserRouter routes (no React Router basename)
-- GitHub Pages deep-link support via `public/404.html` + redirect decoder in `index.html`
+- Deep links are real prerendered HTML under `dist/` (directory-form `…/index.html`); `public/404.html` is a static not-found page for unknown paths (no SPA redirect)
 
 ## Commands
 
@@ -108,7 +108,7 @@ Static deploy-critical files:
 - Keep edits small and targeted.
 - Do not change dependency versions unless requested.
 - Preserve root-deploy assumptions (no base path/basename).
-- If SPA routing behavior changes, update both `public/404.html` and `index.html` decoder logic together.
+- Known routes must exist as prerendered files in `dist/` after `build:static`; `public/404.html` is only for genuinely unknown paths (keep it a real `noindex` page with site links — do not restore the old `sessionStorage` redirect hack).
 - Prefer `npm run build` for the fast inner loop; use `npm run build:static` (or `./script/verify`) when you need prerendered HTML. Prerender requires Playwright Chromium (`npx playwright install chromium`).
 - Adding a route: update the `siteRoutes` registry **and** `public/sitemap.xml` (and `llms.txt`). Prerender reads routes from `dist/sitemap.xml` — no hardcoded route list in the script.
 - Verification pipeline lives in `./script/verify`; `.github/workflows/deploy.yml` calls it — do not duplicate steps in the workflow.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Linters are configured to ignore minified files and vendor libraries. Configurat
 │   │   └── smoke.test.tsx
 │   └── main.tsx         # Entry point
 ├── public/              # Static assets
-│   ├── 404.html         # SPA routing fallback
+│   ├── 404.html         # Static not-found page
 │   ├── CNAME            # Custom domain
 │   ├── favicon.ico
 │   ├── robots.txt
@@ -238,12 +238,9 @@ The app uses React Router's `BrowserRouter` for client-side routing. Routes are 
 - `/projects/bantr` - Bantr project
 - `/projects/signal-storm` - Storm Signal project
 
-### GitHub Pages SPA Support
+### Deep links and 404s
 
-Since GitHub Pages doesn't natively support SPAs, the project includes:
-
-- `public/404.html` - Fallback page that redirects to the SPA
-- Redirect decoder in `index.html` - Handles deep links correctly
+Known routes are prerendered into `dist/` as directory-form HTML (`/projects/bantr` → `dist/projects/bantr/index.html`), so GitHub Pages serves them as real files. `public/404.html` is a static not-found page (`noindex` + site links) for unknown paths — not an SPA redirect.
 
 ### Component Structure
 
@@ -262,7 +259,7 @@ The site is deployed to GitHub Pages via GitHub Actions (`.github/workflows/depl
 Static deploy-critical files in `public/`:
 
 - `CNAME` - Custom domain configuration
-- `404.html` - SPA routing fallback
+- `404.html` - Static not-found page for unknown paths
 - `favicon.ico` - Site favicon
 - `robots.txt` - Search engine directives
 - `sitemap.xml` / `llms.txt` - Discovery files (copied into `dist/`)

--- a/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
+++ b/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
@@ -7,8 +7,8 @@
 | 1 | Discovery files (`sitemap.xml`, `llms.txt`, `siteRoutes`, drift test) | **Merged** (#27) |
 | 2 | Per-route document metadata | **Merged** (#28) |
 | 3 | Prerender script | **Merged** (#29) |
-| 4 | Wire prerender into CI / verify contract | **Done** on `feat/wire-prerender-ci` — open as #30; not yet merged |
-| 5 | Retire SPA redirect hack | Not started |
+| 4 | Wire prerender into CI / verify contract | **Merged** (#30) |
+| 5 | Retire SPA redirect hack | **In progress** on `feat/retire-spa-redirect-404` |
 
 
 ---
@@ -148,9 +148,9 @@ Results buffer in a `Map` and write only after **all** routes pass. Output is di
 
 ---
 
-## PR 4 — Wire into CI and update the verification contract ✅ (not yet merged)
+## PR 4 — Wire into CI and update the verification contract ✅
 
-**Branch:** `feat/wire-prerender-ci` → open as #30.
+**Branch:** `feat/wire-prerender-ci` → merged via #30.
 
 **Goal:** ship prerendered HTML in the Pages artifact, and stop hand-duplicating the verify pipeline across three files.
 
@@ -171,22 +171,24 @@ Results buffer in a `Map` and write only after **all** routes pass. Output is di
 
 Skip Playwright browser caching for now — a stale cache key is a confusing failure mode, and it's an optimization for after the pipeline is proven.
 
-**Verify (done on #30 Actions):** build job ~1m20s; `script/verify --skip-install` prerendered 6 routes; `assert:prerendered` passed; deploy skipped on PR (expected). Production impact still gated on merge to `main`.
+**Verify (done on #30 Actions + live):** build job ~1m20s; `script/verify --skip-install` prerendered 6 routes; `assert:prerendered` passed. After merge to `main`, live curl confirmed all six routes return `data-prerendered` HTML with unique titles and matching canonicals; `sitemap.xml` resolves 200.
 
-**Risk:** First production deploy of prerendered HTML. Mitigated by the PR run proving the pipeline pre-merge.
+**Risk:** First production deploy of prerendered HTML. Mitigated by the PR run proving the pipeline pre-merge; live smoke cleared the gate for PR 5.
 
-**Next:** merge #30 → live smoke of all six routes → PR 5.
+**Next:** PR 5 (retire SPA redirect).
 
 ---
 
 ## PR 5 — Retire the SPA redirect hack (must land last)
 
+**Branch:** `feat/retire-spa-redirect-404`
+
 Every route in this app is a literal — no dynamic params — so once six real files exist, the `sessionStorage` redirect serves *only* genuinely unknown paths, where bouncing to home is a textbook soft 404 that Google flags and that makes a typo'd URL indistinguishable from the homepage.
 
 **Modified**
 - [public/404.html](public/404.html) — replace the redirect script with a real static page: `<h1>Page not found</h1>`, `<meta name="robots" content="noindex">`, links to `/`, `/about`, and the four projects. Inline `<style>` only, since `public/` files bypass the Tailwind bundle.
-- [index.html:24-33](index.html#L24-L33) — delete the decoder script. `CLAUDE.md:105` requires these two to change together; removing both satisfies it.
-- `CLAUDE.md`, `.cursor/rules/iteration-workflow.mdc` — replace the redirect-decoder convention with the prerender-based model.
+- [index.html](index.html) — delete the decoder script. Keep `<title>` / description / favicon as pre-JS defaults.
+- `CLAUDE.md`, `.cursor/rules/iteration-workflow.mdc` — replace the redirect-decoder convention with the prerender-based model. Also aligned `README.md`, `asset-management.mdc`, and `react-structure.mdc`.
 
 **Verify — on the live site, not locally.** `vite preview` does not emulate GitHub Pages' extensionless→directory 301. After PR 4 deploys: `curl -sL https://grantgeist.com/projects/bantr` and the other five routes, confirming real HTML with no JS; then fetch a bogus path and confirm a genuine 404 with links and no redirect.
 

--- a/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
+++ b/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
@@ -8,7 +8,7 @@
 | 2 | Per-route document metadata | **Merged** (#28) |
 | 3 | Prerender script | **Merged** (#29) |
 | 4 | Wire prerender into CI / verify contract | **Merged** (#30) |
-| 5 | Retire SPA redirect hack | **In progress** on `feat/retire-spa-redirect-404` |
+| 5 | Retire SPA redirect hack | **In progress** on `feat/retire-spa-redirect-404` → open as #31 |
 
 
 ---
@@ -186,8 +186,10 @@ Skip Playwright browser caching for now — a stale cache key is a confusing fai
 Every route in this app is a literal — no dynamic params — so once six real files exist, the `sessionStorage` redirect serves *only* genuinely unknown paths, where bouncing to home is a textbook soft 404 that Google flags and that makes a typo'd URL indistinguishable from the homepage.
 
 **Modified**
-- [public/404.html](public/404.html) — replace the redirect script with a real static page: `<h1>Page not found</h1>`, `<meta name="robots" content="noindex">`, links to `/`, `/about`, and the four projects. Inline `<style>` only, since `public/` files bypass the Tailwind bundle.
+- [public/404.html](public/404.html) — replace the redirect script with a real static page: `<h1>Page not found</h1>`, `<meta name="robots" content="noindex">`, Montserrat via Google Fonts, links to `/`, `/about`, and the four projects. Inline `<style>` only, since `public/` files bypass the Tailwind bundle.
 - [index.html](index.html) — delete the decoder script. Keep `<title>` / description / favicon as pre-JS defaults.
+- `NotFound` catch-all route + unknown-path `DocumentMeta` (`noindex` + distinct title/description) so in-SPA unknown URLs match the static 404 behavior.
+- `src/test/not-found-page.test.ts` — drift guard: no `sessionStorage` redirect, `noindex`, font load, every `siteRoutes` path/title linked.
 - `CLAUDE.md`, `.cursor/rules/iteration-workflow.mdc` — replace the redirect-decoder convention with the prerender-based model. Also aligned `README.md`, `asset-management.mdc`, and `react-structure.mdc`.
 
 **Verify — on the live site, not locally.** `vite preview` does not emulate GitHub Pages' extensionless→directory 301. After PR 4 deploys: `curl -sL https://grantgeist.com/projects/bantr` and the other five routes, confirming real HTML with no JS; then fetch a bogus path and confirm a genuine 404 with links and no redirect.

--- a/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
+++ b/docs/sessions/active/2026-07-28-ai-agent-discoverability-plan.md
@@ -8,7 +8,7 @@
 | 2 | Per-route document metadata | **Merged** (#28) |
 | 3 | Prerender script | **Merged** (#29) |
 | 4 | Wire prerender into CI / verify contract | **Merged** (#30) |
-| 5 | Retire SPA redirect hack | **In progress** on `feat/retire-spa-redirect-404` → open as #31 |
+| 5 | Retire SPA redirect hack | **Done** on `feat/retire-spa-redirect-404` — open as #31; not yet merged |
 
 
 ---
@@ -90,9 +90,9 @@ JSON-LD: `Person` + `WebSite` on `/`, `Person` on `/about`, `CreativeWork` + `Br
 - Stopped pointing `og:image` at project `.webp` thumbnails.
 - Deduplicated `absoluteUrl` into a single export from `routeMetadata.ts`.
 
-**Known residual (closes when PR 4 deploys to main)**
-- Until #30 merges and Pages deploys, production still serves pre-prerender HTML — no-JS social scrapers miss OG tags on first paint (static `og:*` removed from `index.html` by design). Google executes JS; prerendered snapshots close the gap once #30 lands on `main`.
-- Unknown paths reuse home title/description with a pathname-specific canonical; PR 5's real 404 should add `noindex` + distinct copy.
+**Known residual (closed by later PRs)**
+- ~~Until #30 merges and Pages deploys, production still serves pre-prerender HTML~~ — closed when #30 deployed; live curl confirmed prerendered HTML + `sitemap.xml` 200.
+- ~~Unknown paths reuse home title/description~~ — closed in PR 5: static `404.html` + in-app `NotFound` + `DocumentMeta` `noindex` with distinct copy.
 
 **Verify (done):** `npx tsc --noEmit && npm run lint:js && npm run test:ci` (document-meta + full suite green after review fixes).
 
@@ -144,7 +144,7 @@ Results buffer in a `Map` and write only after **all** routes pass. Output is di
 
 **Risk:** Highest-complexity PR, but zero production impact until PR 4. Review focus: wait ladder, idempotency guard, `close()` ordering.
 
-**Next:** merge #30, then PR 5 (retire SPA redirect) after live curl checks.
+**Next:** ~~merge #30, then PR 5~~ — done; see PR 4 / PR 5.
 
 ---
 
@@ -175,32 +175,46 @@ Skip Playwright browser caching for now — a stale cache key is a confusing fai
 
 **Risk:** First production deploy of prerendered HTML. Mitigated by the PR run proving the pipeline pre-merge; live smoke cleared the gate for PR 5.
 
-**Next:** PR 5 (retire SPA redirect).
+**Next:** ~~PR 5~~ — open as #31.
 
 ---
 
-## PR 5 — Retire the SPA redirect hack (must land last)
+## PR 5 — Retire the SPA redirect hack ✅ (not yet merged)
 
-**Branch:** `feat/retire-spa-redirect-404`
+**Branch:** `feat/retire-spa-redirect-404` → open as #31.
 
-Every route in this app is a literal — no dynamic params — so once six real files exist, the `sessionStorage` redirect serves *only* genuinely unknown paths, where bouncing to home is a textbook soft 404 that Google flags and that makes a typo'd URL indistinguishable from the homepage.
+Must land last. Every route in this app is a literal — no dynamic params — so once six real files exist, the `sessionStorage` redirect serves *only* genuinely unknown paths, where bouncing to home is a textbook soft 404 that Google flags and that makes a typo'd URL indistinguishable from the homepage.
+
+**Added**
+- `src/app/components/NotFound.tsx` — in-app not-found page (brand, `h1`, site links from `selectedWorkProjects`) for client-side navigation to unknown paths.
+- `src/test/not-found-page.test.ts` — drift guard via `?raw` import of `public/404.html`: `noindex`, no `sessionStorage` / `Redirecting`, Montserrat loaded from Google Fonts, every `siteRoutes` path + title linked.
 
 **Modified**
-- [public/404.html](public/404.html) — replace the redirect script with a real static page: `<h1>Page not found</h1>`, `<meta name="robots" content="noindex">`, Montserrat via Google Fonts, links to `/`, `/about`, and the four projects. Inline `<style>` only, since `public/` files bypass the Tailwind bundle.
+- [public/404.html](public/404.html) — real static page: `<h1>Page not found</h1>`, `<meta name="robots" content="noindex">`, Montserrat via Google Fonts, links to `/`, `/about`, and the four projects. Inline `<style>` only (Guidelines palette); “Selected work” is an `<h2>`.
 - [index.html](index.html) — delete the decoder script. Keep `<title>` / description / favicon as pre-JS defaults.
-- `NotFound` catch-all route + unknown-path `DocumentMeta` (`noindex` + distinct title/description) so in-SPA unknown URLs match the static 404 behavior.
-- `src/test/not-found-page.test.ts` — drift guard: no `sessionStorage` redirect, `noindex`, font load, every `siteRoutes` path/title linked.
+- [App.tsx](src/app/App.tsx) — catch-all `<Route path="*" element={<NotFound />} />`.
+- [routeMetadata.ts](src/app/content/routeMetadata.ts) — unknown paths get distinct title (`Page not found | Grant Geist`), description, empty JSON-LD, and optional `robots: "noindex"`.
+- [DocumentMeta.tsx](src/app/components/DocumentMeta.tsx) — writes managed `meta[name=robots]` when `meta.robots` is set; cleared on navigation to known routes.
+- `src/test/document-meta.test.tsx`, `src/test/app-routing.test.tsx` — cover unknown-path noindex + NotFound route render.
 - `CLAUDE.md`, `.cursor/rules/iteration-workflow.mdc` — replace the redirect-decoder convention with the prerender-based model. Also aligned `README.md`, `asset-management.mdc`, and `react-structure.mdc`.
 
-**Verify — on the live site, not locally.** `vite preview` does not emulate GitHub Pages' extensionless→directory 301. After PR 4 deploys: `curl -sL https://grantgeist.com/projects/bantr` and the other five routes, confirming real HTML with no JS; then fetch a bogus path and confirm a genuine 404 with links and no redirect.
+**Deviations / review hardening (same PR)**
+- First pass only retired the static redirect. Review follow-up added: font load (Montserrat was named but not fetched), `siteRoutes` drift test for 404 links, in-app `NotFound` catch-all, and DocumentMeta `noindex` for unknown paths (closes the PR 2 residual).
 
-**Risk:** Highest of the five. If any prerendered file is missing, that deep link degrades from "works via redirect" to "hard 404." Gated by PR 3's all-or-nothing write and live verification of all six routes before merge.
+**Verify (pre-merge gate done; post-merge live check pending)**
+- After #30 deployed: live curl of all six routes returned `data-prerendered` HTML with unique titles + matching canonicals; `sitemap.xml` → 200. Bogus path still served the old `Redirecting...` page (expected until #31 merges).
+- Local: `npm run lint:js && npm run test:ci` (79 tests, including `not-found-page` + unknown-path DocumentMeta + app-routing NotFound).
+- After #31 merges + Pages deploy: confirm bogus path returns custom 404 (`noindex` + links, no `sessionStorage`) and known deep links still prerender.
+
+**Risk:** Highest of the five. If any prerendered file is missing, that deep link degrades from "works via redirect" to "hard 404." Mitigated by PR 3's all-or-nothing write and live verification of all six routes before opening #31.
+
+**Next:** merge #31 → live bogus-path curl → mark this effort complete.
 
 ---
 
 ## End-to-end verification
 
-After PR 4 deploys, the acceptance test for the whole effort:
+**After PR 4 deploy (done):** all six routes return real prose, a unique `<title>`, a matching `<link rel=canonical>`, JSON-LD, and internal `<a href>` links — with JavaScript never executing. `https://grantgeist.com/sitemap.xml` resolves 200.
 
 ```bash
 for r in / /about /projects/bantr /projects/signal-storm \
@@ -209,7 +223,13 @@ for r in / /about /projects/bantr /projects/signal-storm \
 done
 ```
 
-Every route should return real prose, a unique `<title>`, a matching `<link rel=canonical>`, JSON-LD, and internal `<a href>` links — with JavaScript never executing. `https://grantgeist.com/sitemap.xml` should resolve instead of 404.
+**After PR 5 deploy (pending #31 merge):**
+
+```bash
+curl -sL "https://grantgeist.com/this-path-does-not-exist-xyz" \
+  | grep -E 'noindex|Page not found|sessionStorage|Redirecting'
+# Expect: noindex + Page not found; no sessionStorage / Redirecting
+```
 
 ## Explicitly not doing
 

--- a/index.html
+++ b/index.html
@@ -7,17 +7,6 @@
     <meta name="description" content="Grant Geist — data product strategist, designer, and technologist. Portfolio showcasing work in data visualization, product design, and urban analytics." />
 
     <link rel="icon" href="/favicon.ico" />
-
-    <!-- SPA redirect decoder (works with public/404.html) -->
-    <script>
-      (function () {
-        var redirect = sessionStorage.redirect;
-        delete sessionStorage.redirect;
-        if (redirect && redirect !== location.href) {
-          history.replaceState(null, null, redirect);
-        }
-      })();
-    </script>
   </head>
 
   <body>

--- a/public/404.html
+++ b/public/404.html
@@ -2,18 +2,115 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Redirecting...</title>
-    <script>
-      // Single Page Apps for GitHub Pages
-      // https://github.com/rafgraph/spa-github-pages
-      // Routes defined in the SPA (e.g. /projects/bantr) don't exist as
-      // static files on GitHub Pages, so they 404. This script stores the
-      // current path in sessionStorage and redirects to index.html, which
-      // contains a decoder that restores the path via history.replaceState
-      // before React mounts.
-      sessionStorage.redirect = location.href;
-      location.replace(location.origin);
-    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Page not found | Grant Geist</title>
+    <meta
+      name="description"
+      content="This page does not exist. Browse Grant Geist’s portfolio home, about, and selected work."
+    />
+    <link rel="icon" href="/favicon.ico" />
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem 1.25rem;
+        background-color: #0b0e14;
+        color: #e5e7eb;
+        font-family: Montserrat, "Segoe UI", sans-serif;
+        line-height: 1.5;
+      }
+
+      main {
+        width: 100%;
+        max-width: 36rem;
+      }
+
+      .brand {
+        margin: 0 0 1.5rem;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #9ca3af;
+      }
+
+      .brand a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      .brand a:hover,
+      .brand a:focus-visible {
+        color: #0066cc;
+      }
+
+      h1 {
+        margin: 0 0 0.75rem;
+        font-size: clamp(1.75rem, 4vw, 2.25rem);
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        color: #f9fafb;
+      }
+
+      p {
+        margin: 0 0 1.75rem;
+        color: #9ca3af;
+      }
+
+      nav {
+        display: flex;
+        flex-direction: column;
+        gap: 0.65rem;
+      }
+
+      nav a {
+        color: #0066cc;
+        text-decoration: none;
+        font-weight: 700;
+      }
+
+      nav a:hover,
+      nav a:focus-visible {
+        color: #0052a3;
+        text-decoration: underline;
+      }
+
+      .section-label {
+        margin: 1.5rem 0 0.5rem;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #6b7280;
+      }
+    </style>
   </head>
-  <body></body>
+  <body>
+    <main>
+      <p class="brand"><a href="/">Grant Geist</a></p>
+      <h1>Page not found</h1>
+      <p>That URL isn’t on this site. Try one of these pages instead.</p>
+      <nav aria-label="Site pages">
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+        <p class="section-label">Selected work</p>
+        <a href="/projects/replacement-trap">The Replacement Trap</a>
+        <a href="/projects/signal-storm">Storm Signal</a>
+        <a href="/projects/walkability-index">Walkability Index</a>
+        <a href="/projects/bantr">Bantr</a>
+      </nav>
+    </main>
+  </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -10,6 +10,10 @@
       content="This page does not exist. Browse Grant Geist’s portfolio home, about, and selected work."
     />
     <link rel="icon" href="/favicon.ico" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap"
+    />
     <style>
       :root {
         color-scheme: dark;
@@ -64,7 +68,7 @@
         color: #f9fafb;
       }
 
-      p {
+      .lede {
         margin: 0 0 1.75rem;
         color: #9ca3af;
       }
@@ -101,11 +105,11 @@
     <main>
       <p class="brand"><a href="/">Grant Geist</a></p>
       <h1>Page not found</h1>
-      <p>That URL isn’t on this site. Try one of these pages instead.</p>
+      <p class="lede">That URL isn’t on this site. Try one of these pages instead.</p>
       <nav aria-label="Site pages">
         <a href="/">Home</a>
         <a href="/about">About</a>
-        <p class="section-label">Selected work</p>
+        <h2 class="section-label">Selected work</h2>
         <a href="/projects/replacement-trap">The Replacement Trap</a>
         <a href="/projects/signal-storm">Storm Signal</a>
         <a href="/projects/walkability-index">Walkability Index</a>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import { WorkWithMe } from "@/app/components/WorkWithMe";
 import { Footer } from "@/app/components/Footer";
 import { ErrorBoundary } from "@/app/components/ErrorBoundary";
 import { DocumentMeta } from "@/app/components/DocumentMeta";
+import { NotFound } from "@/app/components/NotFound";
 import { RouteScrollManager } from "@/app/components/RouteScrollManager";
 import {
   bantrProject,
@@ -143,6 +144,7 @@ export default function App() {
             {projectRoutes.map((route) => (
               <Route key={route.path} path={route.path} element={route.element} />
             ))}
+            <Route path="*" element={<NotFound />} />
           </Routes>
 
           <Footer />

--- a/src/app/components/DocumentMeta.tsx
+++ b/src/app/components/DocumentMeta.tsx
@@ -38,6 +38,13 @@ function applyRouteMeta(pathname: string) {
 
   clearManagedMeta();
 
+  if (meta.robots) {
+    const robots = document.createElement("meta");
+    robots.setAttribute("name", "robots");
+    robots.setAttribute("content", meta.robots);
+    appendManagedMeta(robots);
+  }
+
   const link = document.createElement("link");
   link.setAttribute("rel", "canonical");
   link.setAttribute("href", pageUrl);

--- a/src/app/components/NotFound.tsx
+++ b/src/app/components/NotFound.tsx
@@ -1,0 +1,47 @@
+import { Link } from "react-router-dom";
+import { selectedWorkProjects } from "@/app/projects/content/selectedWorkProjects";
+
+/** In-app not-found page for client-side navigation to unknown paths. */
+export function NotFound() {
+  return (
+    <main className="mx-auto flex min-h-[70vh] w-full max-w-xl flex-col justify-center px-6 py-24 lg:px-8">
+      <p className="mb-6 text-xs font-bold uppercase tracking-widest text-gray-500">
+        <Link to="/" className="hover:text-[#0066cc] focus-visible:text-[#0066cc]">
+          Grant Geist
+        </Link>
+      </p>
+      <h1 className="mb-3 text-3xl font-bold tracking-tight text-white md:text-4xl">
+        Page not found
+      </h1>
+      <p className="mb-8 text-base leading-relaxed text-gray-400 md:text-lg">
+        That URL isn’t on this site. Try one of these pages instead.
+      </p>
+      <nav aria-label="Site pages" className="flex flex-col gap-3">
+        <Link
+          to="/"
+          className="font-bold text-[#0066cc] hover:text-[#0052a3] hover:underline focus-visible:text-[#0052a3]"
+        >
+          Home
+        </Link>
+        <Link
+          to="/about"
+          className="font-bold text-[#0066cc] hover:text-[#0052a3] hover:underline focus-visible:text-[#0052a3]"
+        >
+          About
+        </Link>
+        <h2 className="mt-4 text-xs font-bold uppercase tracking-widest text-gray-500">
+          Selected work
+        </h2>
+        {selectedWorkProjects.map((project) => (
+          <Link
+            key={project.route}
+            to={project.route}
+            className="font-bold text-[#0066cc] hover:text-[#0052a3] hover:underline focus-visible:text-[#0052a3]"
+          >
+            {project.title}
+          </Link>
+        ))}
+      </nav>
+    </main>
+  );
+}

--- a/src/app/content/routeMetadata.ts
+++ b/src/app/content/routeMetadata.ts
@@ -17,6 +17,8 @@ export type RouteMeta = {
   ogType: "website" | "article";
   ogImage: string;
   jsonLd: Record<string, unknown> | Record<string, unknown>[];
+  /** When set, DocumentMeta writes a matching robots meta tag. */
+  robots?: "noindex";
 };
 
 /**
@@ -136,14 +138,16 @@ const routeMetaByPath = new Map<string, RouteMeta>([
 
 const unknownPathFallback: RouteMeta = {
   path: "/",
-  title: homeMeta.title,
-  description: homeMeta.description,
+  title: `Page not found${TITLE_SUFFIX}`,
+  description:
+    "This page does not exist. Browse Grant Geist’s portfolio home, about, and selected work.",
   ogType: "website",
   ogImage: DEFAULT_OG_IMAGE,
-  jsonLd: personJsonLd,
+  jsonLd: [],
+  robots: "noindex",
 };
 
-/** Resolve document metadata for a pathname, with home fallback for unknown paths. */
+/** Resolve document metadata for a pathname; unknown paths get distinct noindex copy. */
 export function getRouteMeta(pathname: string): RouteMeta {
   return routeMetaByPath.get(pathname) ?? {
     ...unknownPathFallback,

--- a/src/test/app-routing.test.tsx
+++ b/src/test/app-routing.test.tsx
@@ -41,4 +41,17 @@ describe("App routing integration", () => {
       expect(await screen.findByRole("heading", { level: 1, name: title })).toBeTruthy();
     });
   });
+
+  it("renders the not-found page for unknown paths", async () => {
+    renderAt("/does-not-exist");
+
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Page not found" })
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute("href", "/");
+    expect(screen.getByRole("link", { name: "Bantr" })).toHaveAttribute(
+      "href",
+      "/projects/bantr"
+    );
+  });
 });

--- a/src/test/document-meta.test.tsx
+++ b/src/test/document-meta.test.tsx
@@ -103,10 +103,13 @@ describe("getRouteMeta", () => {
     expect(bantr.ogImage.endsWith(".jpg")).toBe(true);
   });
 
-  it("falls back for unknown paths without inventing a known title", () => {
+  it("uses distinct noindex copy for unknown paths", () => {
     const meta = getRouteMeta("/does-not-exist");
-    expect(meta.title).toBe("Grant Geist | Data Product Strategist");
+    expect(meta.title).toBe(`Page not found${TITLE_SUFFIX}`);
     expect(meta.path).toBe("/does-not-exist");
+    expect(meta.robots).toBe("noindex");
+    expect(meta.description).toMatch(/does not exist/i);
+    expect(meta.jsonLd).toEqual([]);
   });
 
   it("emits home absolute URLs that match sitemap.xml and llms.txt", () => {
@@ -206,5 +209,41 @@ describe("DocumentMeta", () => {
     expect(
       document.querySelector('link[rel="canonical"]')?.getAttribute("href")
     ).toBe(absoluteUrl(bantrProject.route));
+  });
+
+  it("writes noindex for unknown paths and clears it on known navigation", async () => {
+    ensureDescriptionMeta();
+    const { getByRole } = render(
+      <MemoryRouter initialEntries={["/does-not-exist"]}>
+        <DocumentMeta />
+        <Routes>
+          <Route path="/" element={<div>Home</div>} />
+          <Route
+            path="*"
+            element={<NavigateButton to="/" label="To Home" />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(document.title).toBe(`Page not found${TITLE_SUFFIX}`);
+    });
+
+    expect(
+      document
+        .querySelector('meta[name="robots"][data-managed-meta]')
+        ?.getAttribute("content")
+    ).toBe("noindex");
+
+    fireEvent.click(getByRole("button", { name: "To Home" }));
+
+    await waitFor(() => {
+      expect(document.title).toBe(getRouteMeta("/").title);
+    });
+
+    expect(
+      document.querySelector('meta[name="robots"][data-managed-meta]')
+    ).toBeNull();
   });
 });

--- a/src/test/not-found-page.test.ts
+++ b/src/test/not-found-page.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { siteRoutes } from "@/app/content/siteRoutes";
+// Prefer Vite ?raw over node:fs — tsconfig has types: ["vite/client"] only.
+import notFoundHtml from "../../public/404.html?raw";
+
+describe("static 404 page", () => {
+  it("is a real noindex page, not an SPA redirect", () => {
+    expect(notFoundHtml).toContain('name="robots"');
+    expect(notFoundHtml).toContain('content="noindex"');
+    expect(notFoundHtml).toContain("<h1>Page not found</h1>");
+    expect(notFoundHtml).not.toContain("sessionStorage");
+    expect(notFoundHtml).not.toContain("Redirecting");
+  });
+
+  it("loads Montserrat instead of only naming it", () => {
+    expect(notFoundHtml).toMatch(/fonts\.googleapis\.com.*Montserrat/);
+    expect(notFoundHtml).toContain('font-family: Montserrat');
+  });
+
+  it("links every siteRoutes path", () => {
+    for (const route of siteRoutes) {
+      expect(notFoundHtml).toContain(`href="${route.path}"`);
+      expect(notFoundHtml).toContain(`>${route.title}<`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `public/404.html` redirect hack with a real static not-found page (`noindex`, site links, Guidelines palette).
- Remove the `sessionStorage` decoder from `index.html`.
- Update docs/rules (`CLAUDE.md`, iteration-workflow, README, asset/react rules) to the prerender-based deep-link model.

## Gate (live, after #30 deploy)
Verified before opening this PR:
- All six routes return `data-prerendered` HTML with unique titles + matching canonicals
- `https://grantgeist.com/sitemap.xml` → 200
- Bogus path still uses the old redirect until this merges (expected)

## Test plan
- [ ] CI `script/verify --skip-install` green
- [ ] After merge + Pages deploy: `curl -sL https://grantgeist.com/projects/bantr` still returns prerendered HTML
- [ ] `curl -sL https://grantgeist.com/this-path-does-not-exist-xyz` returns custom 404 with `noindex` + links, no `sessionStorage` redirect
- [ ] Spot-check `/`, `/about`, and one other project route still work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production behavior for unknown URLs (no more redirect-to-home soft 404); known deep links now depend entirely on prerendered files, which CI already asserts.
> 
> **Overview**
> Removes the GitHub Pages **sessionStorage** redirect pair (`public/404.html` → home + decoder in `index.html`) now that known routes ship as prerendered HTML in `dist/`.
> 
> **Static 404:** `public/404.html` is a real `noindex` page with inline styling, Montserrat, and links to every `siteRoutes` entry (guarded by `not-found-page.test.ts`).
> 
> **In-app 404:** Adds `NotFound` and a `*` catch-all in `App.tsx`. Unknown paths get distinct metadata via `getRouteMeta` (no home fallback) and `DocumentMeta` emits managed `robots: noindex`, cleared when navigating to known routes.
> 
> Docs (`README`, `CLAUDE.md`, cursor rules) and the discoverability session plan are updated to describe prerender deep links + static 404 instead of the SPA hack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 920c2e902e136a3b3213746e5321c883afe70cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->