### PR TITLE
Feat/llms txt evidence layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ When making changes:
    - Use `npm run lint:fix` to auto-fix issues, but always review changes
    - If npm is unavailable, note linting verification in output
 5. **Adding a route:** update `src/app/content/siteRoutes.ts` (or project registry) **and** `public/sitemap.xml` / `public/llms.txt`. Prerender derives paths from `dist/sitemap.xml`.
-6. **Editing a project's external links (GitHub/demo/essay) or the About timeline:** also update the matching entry in `public/llms.txt` — it restates mechanism/result/evidence per project and the work-history timeline, and `src/test/discovery-files.test.ts` drift-tests both against source.
+6. **Editing a project's external links (GitHub/demo/essay) or the About timeline:** also update the matching entry in `public/llms.txt` — it restates mechanism/result/evidence per project and the work-history timeline, and `src/test/discovery-files.test.ts` drift-tests both against source. Bump its `Last reviewed:` date too (not test-enforced).
 7. If tests/build cannot be run due to environment restrictions:
    - Read `.verify.yml` to understand verification requirements
    - Provide the patch and note: "Verify locally with: ./script/verify"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,8 @@ When making changes:
    - Use `npm run lint:fix` to auto-fix issues, but always review changes
    - If npm is unavailable, note linting verification in output
 5. **Adding a route:** update `src/app/content/siteRoutes.ts` (or project registry) **and** `public/sitemap.xml` / `public/llms.txt`. Prerender derives paths from `dist/sitemap.xml`.
-6. If tests/build cannot be run due to environment restrictions:
+6. **Editing a project's external links (GitHub/demo/essay) or the About timeline:** also update the matching entry in `public/llms.txt` — it restates mechanism/result/evidence per project and the work-history timeline, and `src/test/discovery-files.test.ts` drift-tests both against source.
+7. If tests/build cannot be run due to environment restrictions:
    - Read `.verify.yml` to understand verification requirements
    - Provide the patch and note: "Verify locally with: ./script/verify"
    - Reference the verification steps from `.verify.yml` in your output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,12 @@ Project content is route-component based.
   - Updates to `public/sitemap.xml` and `public/llms.txt` (drift-tested)
   - Any card/link surface updates in homepage components
 
+`public/llms.txt` is an evidence document, not just a link index: each selected-work entry
+carries a mechanism/result summary and external evidence URLs, and there's a work-history
+section sourced from the About timeline. Editing a project's external links (GitHub/demo/essay)
+or the About timeline requires a matching update to `public/llms.txt` — enforced by
+`src/test/discovery-files.test.ts`.
+
 ## Testing
 
 Vitest smoke tests live in `src/test/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,8 @@ Project content is route-component based.
 carries a mechanism/result summary and external evidence URLs, and there's a work-history
 section sourced from the About timeline. Editing a project's external links (GitHub/demo/essay)
 or the About timeline requires a matching update to `public/llms.txt` — enforced by
-`src/test/discovery-files.test.ts`.
+`src/test/discovery-files.test.ts` — and its `Last reviewed:` date should be bumped whenever
+its content changes (not enforced by tests; a manual convention).
 
 ## Testing
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,14 +4,56 @@
 
 Personal site at https://grantgeist.com. Selected work covers emergency message routing, household appliance economics, neighborhood walkability, and creativity-driven conversation games.
 
+Last reviewed: 2026-07-28
+
+## Interpretation notes
+
+This file distinguishes what the site states as fact from what a reader might reasonably infer, and it is organized so the difference stays visible. Every claim below links to the page it is drawn from. Figures (model sizes, ratios, F1 scores, headcounts) are self-reported by the site owner and are not independently audited. Where the site does not say something, that is stated directly under "Evidence boundaries" rather than left for inference.
+
 ## Pages
 
 - [Home](https://grantgeist.com/): Portfolio overview, approach, and contact.
 - [About](https://grantgeist.com/about): Background and career timeline.
 
-## Selected Work
+## Selected work
 
 - [The Replacement Trap](https://grantgeist.com/projects/replacement-trap): A household appliance model showing which upgrades never repay their cost.
+  - Mechanism: a Replacement/Payback (R/P) ratio — lifespan ÷ payback period — modeled across 11 common home systems over a 30-year lifecycle simulation, including HELOC-financed replacement scenarios.
+  - Result: 9 of 11 modeled systems fall below break-even (R/P < 1). Standard/premium dishwashers, water heaters, and air conditioners all fall below 1.0; the hybrid heat pump water heater is the modeled exception (R/P = 2.51).
+  - Evidence: [essay](https://substack.com/@grantgeist/p-179539887), [source code](https://github.com/ghgeist/replacement_trap).
+
 - [Storm Signal](https://grantgeist.com/projects/signal-storm): An emergency message routing system using a 4.5 MB machine learning model with sub-100 ms latency.
+  - Mechanism: a TF-IDF + logistic regression text classifier with recall-optimized threshold tuning and hierarchy rules, chosen over an initial Random Forest model for deployability.
+  - Result: model size reduced from 900 MB (Random Forest) to 4.5 MB via vocabulary filtering and a 15K feature cap; reported inference latency under 100 ms; reported weighted F1 of 92.8% across 36 multi-label categories.
+  - Evidence: [live demo](https://storm-signal.replit.app/), [source code](https://github.com/ghgeist/disaster_response_project).
+
 - [Walkability Index](https://grantgeist.com/projects/walkability-index): A walkability analysis app for neighborhood-scale comparisons.
+  - Mechanism: PostGIS-backed queries over the U.S. EPA's National Walkability Index, with radius filtering, spatial indexing, and geometry simplification; supports side-by-side location comparison on a 1–20 NWI scale.
+  - The project page publishes its own current limitations directly: geocoder reliability depends on third-party services (Nominatim, with a Census geocoder fallback), radius edge cases at small radii or coastal boundaries, scores are averaged at census-block-group granularity (not parcel-level), and the Compare view has fewer capabilities than the Explore view.
+  - Evidence: [live demo](https://walkability-index.replit.app/), [source code](https://github.com/ghgeist/urbanism_project).
+
 - [Bantr](https://grantgeist.com/projects/bantr): A mobile-first platform for creativity-driven conversation games.
+  - Mechanism: React + Express + Postgres, with OpenAI-generated conversation prompts behind a moderation gate and format validation, guest-first identity, and Stripe subscription billing.
+  - Result: shipped to production; the project page states users complete full 10-question rounds and receive personalized summaries. The project page also states that adoption has remained limited without a defined distribution channel — this is the site's own stated constraint, not an inferred one.
+  - Evidence: [live demo](https://bantr.us/).
+
+## Work history (source: /about)
+
+- 2013 — Macon, GA (Mercer University): studied chemistry and biology alongside poverty economics, focused on which interventions hold up at scale.
+- 2013–2015 — Mozambique (U.S. Peace Corps): secured grant funding and implemented drip irrigation at an agricultural technical school previously dependent on rain-fed crops.
+- 2015–2016 — Dubai (Bloomberg): built Excel- and Bloomberg API-based monitoring systems supporting FX and bond market expansion across Africa and the Middle East, including long-term monitoring of the Ghanaian bond market.
+- 2016–2021 — New York (Bloomberg): built analytics infrastructure for a 121-person department; led an anomaly detection project correcting 2.1M inconsistencies across 18TB of data.
+- 2021–2023 — New York (VTS): migrated core business logic from Looker PDTs into dbt, consolidating 23 production metrics for a 146-person organization during a $125M Series E.
+- 2022–2024 — Rhode Island School of Design (RISD) (Product Design & Manufacturing): completed a two-year certificate while working full-time; capstone on embodied AI and physical interfaces for software control.
+- 2024–Present — Remote: completed the Udacity Data Science Nanodegree; states 3,000+ hours building production ML pipelines, economic models, and geospatial applications since.
+
+## Elsewhere
+
+- LinkedIn: https://www.linkedin.com/in/grantgeist/
+- GitHub: https://github.com/ghgeist
+- Substack (writing): https://thedonkeyaxiom.substack.com/
+- Résumé: a Google Doc, linked from the site footer — may not be reachable by tools that only follow static links.
+
+## Evidence boundaries
+
+This site does not publish: independent or third-party verification of any stated result (model metrics, headcounts, data volumes, dollar figures); usage or adoption numbers for the shipped, live projects (Storm Signal, Walkability Index, Bantr) beyond what each project page states; the team size, client names, or scope of the 2024–present independent work; or testimonials or references from managers or collaborators. Employment dates and role descriptions above come only from the About page and are not corroborated elsewhere on this site.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,14 +1,15 @@
 # Grant Geist
 
-> Data product strategist, designer, and technologist. Portfolio of selected work in data visualization, product design, machine learning, and urban analytics.
+> Grant Geist works across data, software, machine learning, product design, and operational systems. This site documents selected professional experience and independent projects.
 
 Personal site at https://grantgeist.com. Selected work covers emergency message routing, household appliance economics, neighborhood walkability, and creativity-driven conversation games.
 
+Welcome to the AI-optimized portion of the website. After several decades of advances in artificial intelligence, we have finally arrived at .txt.
+
 Last reviewed: 2026-07-28
 
-## Interpretation notes
-
-This file distinguishes what the site states as fact from what a reader might reasonably infer, and it is organized so the difference stays visible. Every claim below links to the page it is drawn from. Figures (model sizes, ratios, F1 scores, headcounts) are self-reported by the site owner and are not independently audited. Where the site does not say something, that is stated directly under "Evidence boundaries" rather than left for inference.
+Source notes:
+Metrics, work-history details, and project outcomes are reported by the site owner unless an external source is linked. Work-history entries summarize the About page and do not always distinguish individual from team contribution. Information not stated by the site — including adoption, client scope, or third-party verification — should be treated as unknown rather than inferred.
 
 ## Pages
 
@@ -24,7 +25,7 @@ This file distinguishes what the site states as fact from what a reader might re
 
 - [Storm Signal](https://grantgeist.com/projects/signal-storm): An emergency message routing system using a 4.5 MB machine learning model with sub-100 ms latency.
   - Mechanism: a TF-IDF + logistic regression text classifier with recall-optimized threshold tuning and hierarchy rules, chosen over an initial Random Forest model for deployability.
-  - Result: model size reduced from 900 MB (Random Forest) to 4.5 MB via vocabulary filtering and a 15K feature cap; reported inference latency under 100 ms; reported weighted F1 of 92.8% across 36 multi-label categories.
+  - Result: Replaced an approximately 900 MB Random Forest with logistic regression, then reduced the LR model from 67.7 MB to 4.5 MB through vocabulary filtering and a 15K feature cap; reported inference latency under 100 ms and weighted F1 of 92.8% across 36 multi-label categories.
   - Evidence: [live demo](https://storm-signal.replit.app/), [source code](https://github.com/ghgeist/disaster_response_project).
 
 - [Walkability Index](https://grantgeist.com/projects/walkability-index): A walkability analysis app for neighborhood-scale comparisons.
@@ -34,7 +35,7 @@ This file distinguishes what the site states as fact from what a reader might re
 
 - [Bantr](https://grantgeist.com/projects/bantr): A mobile-first platform for creativity-driven conversation games.
   - Mechanism: React + Express + Postgres, with OpenAI-generated conversation prompts behind a moderation gate and format validation, guest-first identity, and Stripe subscription billing.
-  - Result: shipped to production; the project page states users complete full 10-question rounds and receive personalized summaries. The project page also states that adoption has remained limited without a defined distribution channel — this is the site's own stated constraint, not an inferred one.
+  - Result: shipped to production; the shipped flow supports complete 10-question rounds and personalized summaries. The project page also states that adoption has remained limited without a defined distribution channel — this is the site's own stated constraint, not an inferred one.
   - Evidence: [live demo](https://bantr.us/).
 
 ## Work history (source: /about)
@@ -44,7 +45,7 @@ This file distinguishes what the site states as fact from what a reader might re
 - 2015–2016 — Dubai (Bloomberg): built Excel- and Bloomberg API-based monitoring systems supporting FX and bond market expansion across Africa and the Middle East, including long-term monitoring of the Ghanaian bond market.
 - 2016–2021 — New York (Bloomberg): built analytics infrastructure for a 121-person department; led an anomaly detection project correcting 2.1M inconsistencies across 18TB of data.
 - 2021–2023 — New York (VTS): migrated core business logic from Looker PDTs into dbt, consolidating 23 production metrics for a 146-person organization during a $125M Series E.
-- 2022–2024 — Rhode Island School of Design (RISD) (Product Design & Manufacturing): completed a two-year certificate while working full-time; capstone on embodied AI and physical interfaces for software control.
+- 2022–2024 — Rhode Island School of Design (RISD): completed a two-year Product Design & Manufacturing certificate while working full-time; capstone on embodied AI and physical interfaces for software control.
 - 2024–Present — Remote: completed the Udacity Data Science Nanodegree; states 3,000+ hours building production ML pipelines, economic models, and geospatial applications since.
 
 ## Elsewhere
@@ -52,8 +53,3 @@ This file distinguishes what the site states as fact from what a reader might re
 - LinkedIn: https://www.linkedin.com/in/grantgeist/
 - GitHub: https://github.com/ghgeist
 - Substack (writing): https://thedonkeyaxiom.substack.com/
-- Résumé: a Google Doc, linked from the site footer — may not be reachable by tools that only follow static links.
-
-## Evidence boundaries
-
-This site does not publish: independent or third-party verification of any stated result (model metrics, headcounts, data volumes, dollar figures); usage or adoption numbers for the shipped, live projects (Storm Signal, Walkability Index, Bantr) beyond what each project page states; the team size, client names, or scope of the 2024–present independent work; or testimonials or references from managers or collaborators. Employment dates and role descriptions above come only from the About page and are not corroborated elsewhere on this site.

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -67,6 +67,11 @@ export function Footer() {
               title="A machine-readable version of this site, for AI agents and evaluators."
             >
               llms.txt
+              <span className="sr-only">
+                {" "}
+                — a machine-readable version of this site, for AI agents and
+                evaluators
+              </span>
             </a>
           </p>
 

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -57,7 +57,17 @@ export function Footer() {
           
           {/* Left: Copyright */}
           <p className="text-sm text-gray-500">
-            © {year} Grant Geist. All rights reserved.
+            © {year} Grant Geist. All rights reserved.{" "}
+            <span className="text-gray-700" aria-hidden="true">
+              ·
+            </span>{" "}
+            <a
+              href="/llms.txt"
+              className="text-gray-600 transition-colors hover:text-gray-400"
+              title="A machine-readable version of this site, for AI agents and evaluators."
+            >
+              llms.txt
+            </a>
           </p>
 
           {/* Right: Social Links */}

--- a/src/app/content/routeMetadata.ts
+++ b/src/app/content/routeMetadata.ts
@@ -38,7 +38,11 @@ const personJsonLd = {
   name: PERSON_NAME,
   jobTitle: PERSON_JOB_TITLE,
   url: absoluteUrl("/"),
-  sameAs: ["https://www.linkedin.com/in/grantgeist/"],
+  sameAs: [
+    "https://www.linkedin.com/in/grantgeist/",
+    "https://github.com/ghgeist",
+    "https://thedonkeyaxiom.substack.com/",
+  ],
 } as const;
 
 const websiteJsonLd = {

--- a/src/test/discovery-files.test.ts
+++ b/src/test/discovery-files.test.ts
@@ -6,6 +6,11 @@ import { SITE_URL, siteRoutes } from "@/app/content/siteRoutes";
 // and adding @types/node is an unrequested dependency change (AGENTS.md).
 import sitemap from "../../public/sitemap.xml?raw";
 import llmsTxt from "../../public/llms.txt?raw";
+import aboutSource from "../app/components/About.tsx?raw";
+import replacementTrapSource from "../app/projects/ReplacementTrap.tsx?raw";
+import stormSignalSource from "../app/projects/StormSignal.tsx?raw";
+import walkabilityIndexSource from "../app/projects/WalkabilityIndex.tsx?raw";
+import bantrSource from "../app/projects/Bantr.tsx?raw";
 
 function extractSitemapLocs(xml: string): string[] {
   return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]);
@@ -16,6 +21,59 @@ function extractMarkdownHrefs(markdown: string): string[] {
     (match) => match[1]
   );
 }
+
+/** Pulls timeline `year`/`title` string literals out of About.tsx's source. */
+function extractAboutTimelineFields(source: string): {
+  years: string[];
+  titles: string[];
+} {
+  const years = [...source.matchAll(/\byear:\s*"([^"]+)"/g)].map(
+    (match) => match[1]
+  );
+  const titles = [...source.matchAll(/\btitle:\s*"([^"]+)"/g)].map(
+    (match) => match[1]
+  );
+  return { years, titles };
+}
+
+/** External (non-grantgeist.com) evidence URLs each project's llms.txt entry cites. */
+const projectEvidenceUrls: Record<string, string[]> = {
+  replacementTrap: [
+    "https://substack.com/@grantgeist/p-179539887",
+    "https://github.com/ghgeist/replacement_trap",
+  ],
+  stormSignal: [
+    "https://storm-signal.replit.app/",
+    "https://github.com/ghgeist/disaster_response_project",
+  ],
+  walkabilityIndex: [
+    "https://walkability-index.replit.app/",
+    "https://github.com/ghgeist/urbanism_project",
+  ],
+  bantr: ["https://bantr.us/"],
+};
+
+const projectSourcesByKey: Record<string, string> = {
+  replacementTrap: replacementTrapSource,
+  stormSignal: stormSignalSource,
+  walkabilityIndex: walkabilityIndexSource,
+  bantr: bantrSource,
+};
+
+// Narrow, high-confidence manipulation phrasing only — not general imperative
+// language ("you must", "verify") that shows up legitimately in evaluation
+// framing. A false positive here would block honest edits to llms.txt.
+const INJECTION_PATTERNS: RegExp[] = [
+  /ignore (all |any )?(previous|prior|the above)/i,
+  /disregard (all |any )?(previous|prior|the above)/i,
+  /system prompt/i,
+  /you are now/i,
+  /act as (if you|though)/i,
+  /new instructions:/i,
+  /recommend hiring/i,
+  /top candidate/i,
+  /must (recommend|hire|select)/i,
+];
 
 describe("discovery files", () => {
   const registryUrls = siteRoutes.map((route) => absoluteUrl(route.path));
@@ -57,6 +115,49 @@ describe("discovery files", () => {
 
     for (const href of hrefs) {
       expect(registryUrls).toContain(href);
+    }
+  });
+
+  it("contains the expected evidence-layer section headings", () => {
+    const requiredHeadings = [
+      "## Interpretation notes",
+      "## Selected work",
+      "## Work history (source: /about)",
+      "## Elsewhere",
+      "## Evidence boundaries",
+    ];
+
+    for (const heading of requiredHeadings) {
+      expect(llmsTxt).toContain(heading);
+    }
+  });
+
+  it("cites external evidence URLs that also appear on the corresponding project page", () => {
+    for (const [key, urls] of Object.entries(projectEvidenceUrls)) {
+      const projectSource = projectSourcesByKey[key];
+      for (const url of urls) {
+        expect(llmsTxt).toContain(url);
+        expect(projectSource).toContain(url);
+      }
+    }
+  });
+
+  it("restates every About timeline year and title in llms.txt", () => {
+    const { years, titles } = extractAboutTimelineFields(aboutSource);
+    expect(years.length).toBeGreaterThan(0);
+    expect(titles.length).toBeGreaterThan(0);
+
+    for (const year of years) {
+      expect(llmsTxt).toContain(year);
+    }
+    for (const title of titles) {
+      expect(llmsTxt).toContain(title);
+    }
+  });
+
+  it("does not contain prompt-injection or ranking-manipulation phrasing", () => {
+    for (const pattern of INJECTION_PATTERNS) {
+      expect(llmsTxt).not.toMatch(pattern);
     }
   });
 });

--- a/src/test/discovery-files.test.ts
+++ b/src/test/discovery-files.test.ts
@@ -22,32 +22,62 @@ function extractMarkdownHrefs(markdown: string): string[] {
   );
 }
 
+type AboutTimelineEntry = {
+  year: string;
+  titleFragments: string[];
+};
+
 /**
- * Pulls timeline `year` values and `title` fragments out of About.tsx's
- * source. Titles are split into their base name and parenthetical asides
+ * Splits a timeline title into its base name and parenthetical asides
  * (e.g. `"Rhode Island School of Design (RISD) (Product Design & Manufacturing)"`
  * → `["Rhode Island School of Design", "RISD", "Product Design & Manufacturing"]`)
  * so llms.txt can reword/reorder a title's parts instead of being forced to
  * repeat an awkward, fully concatenated string verbatim.
  */
-function extractAboutTimelineFields(source: string): {
-  years: string[];
-  titleFragments: string[];
-} {
+function splitTitleFragments(title: string): string[] {
+  const parenthetical = [...title.matchAll(/\(([^)]+)\)/g)].map(
+    (match) => match[1]
+  );
+  const base = title.replace(/\s*\([^)]*\)/g, "").trim();
+  return [base, ...parenthetical].filter((fragment) => fragment.length > 0);
+}
+
+/**
+ * Pulls paired timeline `year` + title fragments out of About.tsx so each
+ * entry is checked as a unit. Independent year/fragment substring checks are
+ * too weak: "2013" appears inside "2013–2015", and shared fragments like
+ * "New York" / "Bloomberg" can survive after a sibling line is deleted.
+ */
+function extractAboutTimelineEntries(source: string): AboutTimelineEntry[] {
   const years = [...source.matchAll(/\byear:\s*"([^"]+)"/g)].map(
     (match) => match[1]
   );
   const titles = [...source.matchAll(/\btitle:\s*"([^"]+)"/g)].map(
     (match) => match[1]
   );
-  const titleFragments = titles.flatMap((title) => {
-    const parenthetical = [...title.matchAll(/\(([^)]+)\)/g)].map(
-      (match) => match[1]
+  if (years.length !== titles.length) {
+    throw new Error(
+      `About timeline year/title count mismatch: ${years.length} years, ${titles.length} titles`
     );
-    const base = title.replace(/\s*\([^)]*\)/g, "").trim();
-    return [base, ...parenthetical].filter((fragment) => fragment.length > 0);
-  });
-  return { years, titleFragments };
+  }
+  return years.map((year, index) => ({
+    year,
+    titleFragments: splitTitleFragments(titles[index]),
+  }));
+}
+
+/** Bullet lines under the Work history section of llms.txt. */
+function extractWorkHistoryLines(markdown: string): string[] {
+  const sectionMatch = markdown.match(
+    /## Work history \(source: \/about\)\r?\n\r?\n([\s\S]*?)(?=\r?\n## |\r?\n*$)/
+  );
+  if (!sectionMatch) {
+    return [];
+  }
+  return sectionMatch[1]
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "));
 }
 
 const projectSourcesByKey: Record<string, string> = {
@@ -154,16 +184,21 @@ describe("discovery files", () => {
     }
   });
 
-  it("restates every About timeline year and title fragment in llms.txt", () => {
-    const { years, titleFragments } = extractAboutTimelineFields(aboutSource);
-    expect(years.length).toBeGreaterThan(0);
-    expect(titleFragments.length).toBeGreaterThan(0);
+  it("restates every About timeline entry as a work-history line", () => {
+    const entries = extractAboutTimelineEntries(aboutSource);
+    const lines = extractWorkHistoryLines(llmsTxt);
+    expect(entries.length).toBeGreaterThan(0);
+    expect(lines.length).toBe(entries.length);
 
-    for (const year of years) {
-      expect(llmsTxt).toContain(year);
-    }
-    for (const fragment of titleFragments) {
-      expect(llmsTxt).toContain(fragment);
+    for (const entry of entries) {
+      // Exact year prefix (`- 2013 —`) so "2013" cannot match "2013–2015".
+      const line = lines.find((candidate) =>
+        candidate.startsWith(`- ${entry.year} —`)
+      );
+      expect(line).toBeDefined();
+      for (const fragment of entry.titleFragments) {
+        expect(line).toContain(fragment);
+      }
     }
   });
 

--- a/src/test/discovery-files.test.ts
+++ b/src/test/discovery-files.test.ts
@@ -22,10 +22,17 @@ function extractMarkdownHrefs(markdown: string): string[] {
   );
 }
 
-/** Pulls timeline `year`/`title` string literals out of About.tsx's source. */
+/**
+ * Pulls timeline `year` values and `title` fragments out of About.tsx's
+ * source. Titles are split into their base name and parenthetical asides
+ * (e.g. `"Rhode Island School of Design (RISD) (Product Design & Manufacturing)"`
+ * → `["Rhode Island School of Design", "RISD", "Product Design & Manufacturing"]`)
+ * so llms.txt can reword/reorder a title's parts instead of being forced to
+ * repeat an awkward, fully concatenated string verbatim.
+ */
 function extractAboutTimelineFields(source: string): {
   years: string[];
-  titles: string[];
+  titleFragments: string[];
 } {
   const years = [...source.matchAll(/\byear:\s*"([^"]+)"/g)].map(
     (match) => match[1]
@@ -33,7 +40,14 @@ function extractAboutTimelineFields(source: string): {
   const titles = [...source.matchAll(/\btitle:\s*"([^"]+)"/g)].map(
     (match) => match[1]
   );
-  return { years, titles };
+  const titleFragments = titles.flatMap((title) => {
+    const parenthetical = [...title.matchAll(/\(([^)]+)\)/g)].map(
+      (match) => match[1]
+    );
+    const base = title.replace(/\s*\([^)]*\)/g, "").trim();
+    return [base, ...parenthetical].filter((fragment) => fragment.length > 0);
+  });
+  return { years, titleFragments };
 }
 
 /** External (non-grantgeist.com) evidence URLs each project's llms.txt entry cites. */
@@ -119,12 +133,11 @@ describe("discovery files", () => {
   });
 
   it("contains the expected evidence-layer section headings", () => {
+    expect(llmsTxt).toContain("Source notes:");
     const requiredHeadings = [
-      "## Interpretation notes",
       "## Selected work",
       "## Work history (source: /about)",
       "## Elsewhere",
-      "## Evidence boundaries",
     ];
 
     for (const heading of requiredHeadings) {
@@ -142,16 +155,16 @@ describe("discovery files", () => {
     }
   });
 
-  it("restates every About timeline year and title in llms.txt", () => {
-    const { years, titles } = extractAboutTimelineFields(aboutSource);
+  it("restates every About timeline year and title fragment in llms.txt", () => {
+    const { years, titleFragments } = extractAboutTimelineFields(aboutSource);
     expect(years.length).toBeGreaterThan(0);
-    expect(titles.length).toBeGreaterThan(0);
+    expect(titleFragments.length).toBeGreaterThan(0);
 
     for (const year of years) {
       expect(llmsTxt).toContain(year);
     }
-    for (const title of titles) {
-      expect(llmsTxt).toContain(title);
+    for (const fragment of titleFragments) {
+      expect(llmsTxt).toContain(fragment);
     }
   });
 

--- a/src/test/discovery-files.test.ts
+++ b/src/test/discovery-files.test.ts
@@ -50,29 +50,27 @@ function extractAboutTimelineFields(source: string): {
   return { years, titleFragments };
 }
 
-/** External (non-grantgeist.com) evidence URLs each project's llms.txt entry cites. */
-const projectEvidenceUrls: Record<string, string[]> = {
-  replacementTrap: [
-    "https://substack.com/@grantgeist/p-179539887",
-    "https://github.com/ghgeist/replacement_trap",
-  ],
-  stormSignal: [
-    "https://storm-signal.replit.app/",
-    "https://github.com/ghgeist/disaster_response_project",
-  ],
-  walkabilityIndex: [
-    "https://walkability-index.replit.app/",
-    "https://github.com/ghgeist/urbanism_project",
-  ],
-  bantr: ["https://bantr.us/"],
-};
-
 const projectSourcesByKey: Record<string, string> = {
   replacementTrap: replacementTrapSource,
   stormSignal: stormSignalSource,
   walkabilityIndex: walkabilityIndexSource,
   bantr: bantrSource,
 };
+
+/**
+ * Pulls external `href` values from a project page's `const ctas = [...]`
+ * block. Evidence in llms.txt must cover every CTA so a new demo/repo link
+ * cannot land on a project page while being omitted from the evidence layer.
+ */
+function extractCtaHrefs(source: string): string[] {
+  const ctasMatch = source.match(/const ctas = \[([\s\S]*?)\];/);
+  if (!ctasMatch) {
+    return [];
+  }
+  return [...ctasMatch[1].matchAll(/href:\s*"(https?:\/\/[^"]+)"/g)].map(
+    (match) => match[1]
+  );
+}
 
 // Narrow, high-confidence manipulation phrasing only — not general imperative
 // language ("you must", "verify") that shows up legitimately in evaluation
@@ -145,12 +143,13 @@ describe("discovery files", () => {
     }
   });
 
-  it("cites external evidence URLs that also appear on the corresponding project page", () => {
-    for (const [key, urls] of Object.entries(projectEvidenceUrls)) {
-      const projectSource = projectSourcesByKey[key];
-      for (const url of urls) {
-        expect(llmsTxt).toContain(url);
-        expect(projectSource).toContain(url);
+  it("includes every project page CTA href in llms.txt", () => {
+    for (const [, projectSource] of Object.entries(projectSourcesByKey)) {
+      const hrefs = extractCtaHrefs(projectSource);
+      expect(hrefs.length).toBeGreaterThan(0);
+
+      for (const href of hrefs) {
+        expect(llmsTxt).toContain(href);
       }
     }
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Content, tests, and minor SEO/footer changes only; no auth, data pipelines, or routing behavior changes.
> 
> **Overview**
> Turns **`public/llms.txt`** from a route index into an **evidence document** for agents: **Source notes**, per-project **mechanism/result/evidence** bullets, a **Work history** section mirroring About, and an **Elsewhere** block for GitHub/Substack/LinkedIn, plus a **Last reviewed** date.
> 
> **`src/test/discovery-files.test.ts`** gains drift checks so `llms.txt` stays aligned with the app: required section headings, every project **`ctas`** external `href`, paired About timeline **year/title** lines (not loose substring matches), and a guard against prompt-injection / hiring-manipulation phrasing.
> 
> **`AGENTS.md`** and **`CLAUDE.md`** document that timeline/CTA edits must update `llms.txt` and bump **Last reviewed**.
> 
> The **footer** adds a discoverable **`/llms.txt`** link (with accessible labeling). **`routeMetadata.ts`** extends Person **`sameAs`** JSON-LD with GitHub and Substack to match the new Elsewhere links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 974628762cbda71a6f6a7d8015cce26095455249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->